### PR TITLE
Add Codeowners and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Main maintainers
+*                       @ewjoachim @mgu @pmourlanne
+
+# Documentation
+/docs/                  @ewjoachim @mgu @pmourlanne @CorBott

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+Cf. #<ticket number>
+
+### Succesful PR Checklist:
+- [ ] Tests
+- [ ] Documentation
+- [ ] Had a good time contributing? (if not, feel free to give some feedback)


### PR DESCRIPTION
In this PR, we name @mgu @pmourlanne and I as codeowners, and @CorBott as documentation codeowner. I've written the file so that no one ever is a bottleneck.

Also, I'm adding a PR template which should help us remember to always always (always) add some documentation. (and maybe get some feedback about the contribution process)