### PR TITLE
Don't overwrite psycopg2 adapters when creating the connection

### DIFF
--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -17,7 +17,7 @@ def wrap_json(arguments: Dict[str, Any]):
 
 def get_connection(dsn="", **kwargs) -> Awaitable[aiopg.Connection]:
     # tell aiopg not to register adapters for hstore & json by default, as
-    # those are registered at the module level and could overwritte previously
+    # those are registered at the module level and could overwrite previously
     # defined adapters
     kwargs.setdefault("enable_json", False)
     kwargs.setdefault("enable_hstore", False)

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -16,6 +16,11 @@ def wrap_json(arguments: Dict[str, Any]):
 
 
 def get_connection(dsn="", **kwargs) -> Awaitable[aiopg.Connection]:
+    # tell aiopg not to register adapters for hstore & json by default, as
+    # those are registered at the module level and could overwritte previously
+    # defined adapters
+    kwargs.setdefault("enable_json", False)
+    kwargs.setdefault("enable_hstore", False)
     return aiopg.connect(dsn=dsn, **kwargs)
 
 


### PR DESCRIPTION
If an application had registered psycopg2 adapters, the next call to `get_connection` would overwrite them with aiopg's default. As we don't need the adapters registered by aiopg, we can safely tell it not to do that by default.