### PR TITLE
disable warning task name different from python path

### DIFF
--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -67,6 +67,7 @@ class App:
         queue: str = jobs.DEFAULT_QUEUE,
         name: Optional[str] = None,
         retry: retry_module.RetryValue = False,
+        disable_full_path_warning: bool = False,
     ) -> Any:
         """
         Declare a function as a task. This method is meant to be used as a decorator::
@@ -113,7 +114,8 @@ class App:
         def _wrap(func: Callable[..., "tasks.Task"]):
             from procrastinate import tasks
 
-            task = tasks.Task(func, app=self, queue=queue, name=name, retry=retry)
+            task = tasks.Task(func, app=self, queue=queue, name=name, retry=retry, disable_full_path_warning=
+                disable_full_path_warning)
             self._register(task)
 
             return functools.update_wrapper(task, func)

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -114,8 +114,9 @@ class App:
         def _wrap(func: Callable[..., "tasks.Task"]):
             from procrastinate import tasks
 
-            task = tasks.Task(func, app=self, queue=queue, name=name, retry=retry, disable_full_path_warning=
-                disable_full_path_warning)
+            task = tasks.Task(
+                func, app=self, queue=queue, name=name, retry=retry,
+                disable_full_path_warning=disable_full_path_warning)
             self._register(task)
 
             return functools.update_wrapper(task, func)

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -62,6 +62,7 @@ class Task:
         queue: str,
         name: Optional[str] = None,
         retry: retry_module.RetryValue = False,
+        disable_full_path_warning: bool = False,
     ):
         self.queue = queue
         self.app = app
@@ -80,7 +81,7 @@ class Task:
                 # Can happen for functools.partial for example
                 full_path = ""
 
-            if full_path and name != full_path:
+            if not disable_full_path_warning and full_path and name != full_path:
                 logger.warning(
                     f"Task {name} at {self.full_path} has a name that doesn't match "
                     "its import path. Please make sure its module path is provided in "


### PR DESCRIPTION
Cf. #112 

My solution is to add the boolean attribute on the decorator of a task.( `@app.task(disable_full_path_warning=True)`. I tried to add tests for this feature but I don't know how to mock ``__name__`` and ``__module__`` attributes of func in Task.

### Successful PR Checklist:
- [ ] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [ ] Had a good time contributing? (if not, feel free to give some feedback)
