### PR TITLE
Remove the Task name/full_path warning

### DIFF
--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -67,30 +67,7 @@ class Task:
         self.app = app
         self.func: Callable = func
         self.retry_strategy = retry_module.get_retry_strategy(retry)
-        self.name: str
-        if name:
-            self.name = name
-        else:
-            self.name = self.full_path
-
-        if name:
-            try:
-                full_path = self.full_path
-            except AttributeError:
-                # Can happen for functools.partial for example
-                full_path = ""
-
-            if full_path and name != full_path:
-                logger.warning(
-                    f"Task {name} at {self.full_path} has a name that doesn't match "
-                    "its import path. Please make sure its module path is provided in "
-                    "the worker's import_paths, or it won't run.",
-                    extra={
-                        "action": "task_name_differ_from_path",
-                        "task_name": name,
-                        "task_path": self.full_path,
-                    },
-                )
+        self.name: str = name if name else self.full_path
 
     def __call__(self, **kwargs: types.JSONValue) -> Any:
         return self.func(**kwargs)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -17,18 +17,6 @@ def test_task_init_with_no_name(app):
     assert task.name == "tests.unit.test_tasks.task_func"
 
 
-def test_task_init_explicit_name(app, mocker, caplog):
-    task = tasks.Task(task_func, app=app, queue="queue", name="other")
-
-    assert task.name == "other"
-
-    assert [
-        record
-        for record in caplog.records
-        if record.action == "task_name_differ_from_path"
-    ]
-
-
 def test_task_defer(app):
     task = tasks.Task(task_func, app=app, queue="queue")
 


### PR DESCRIPTION
Cf. #112 and #118.

This PR is an alternative to #118. It suggests to completely remove the warning that occurs when creating a task whose name is not its import path.

Motivation/rationale: when creating a task (for example using the `app.task` decorator) it is perfectly valid to provide an arbitrary task name. So, really, procrastinate shouldn't emit a warning when the task name doesn't correspond to the function's dotted name. And we already have a warning message on the worker side when the user didn't specify the task module (with `import_paths`) and when the task module was loaded dynamically.

Closes #112

### Successful PR Checklist:
- [X] Tests (no new tests, but existing tests pass, with no coverage regression)
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [X] Had a good time contributing? (if not, feel free to give some feedback)
