### PR TITLE
Use asyncio.TimeoutError

### DIFF
--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -61,7 +61,7 @@ def make_dynamic_query(query: str, **identifiers: str) -> str:
 async def wait_for_jobs(connection: aiopg.Connection, socket_timeout: float):
     try:
         await asyncio.wait_for(connection.notifies.get(), timeout=socket_timeout)
-    except asyncio.futures.TimeoutError:
+    except asyncio.TimeoutError:
         pass
 
 


### PR DESCRIPTION
Use `asyncio.TimeoutError` rather than `asyncio.futures.TimeoutError`, the latter producing an `AttributeError` with Python 3.8.

The [`asyncio.wait_for` docs](https://docs.python.org/3.8/library/asyncio-task.html?highlight=wait_for#asyncio.wait_for) indicate that `asyncio.TimeoutError` is raised when a timeout occurs, and this for Python 3.5, 3.6, 3.7 and 3.8. So the use of `asyncio.TimeoutError` is safe across Python 3.x versions.

Fixes #124.

### Successful PR Checklist:
- [x] Tests
- [x] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation)) **Not relevant**
- [X] Had a good time contributing? (if not, feel free to give some feedback)
