### PR TITLE
Make two tests in test_testing async

### DIFF
--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -254,14 +254,16 @@ def test_finish_job_run_retry_no_schedule(job_store):
     assert len(job_store.events[id]) == 3
 
 
-def test_listen_for_jobs_run(job_store):
+@pytest.mark.asyncio
+async def test_listen_for_jobs_run(job_store):
     # If we don't crash, it's enough
-    job_store.listen_for_jobs(queues=["a", "b"])
+    await job_store.listen_for_jobs(queues=["a", "b"])
 
 
-def test_wait_for_jobs(job_store):
+@pytest.mark.asyncio
+async def test_wait_for_jobs(job_store):
     # If we don't crash, it's enough
-    job_store.wait_for_jobs()
+    await job_store.wait_for_jobs()
 
 
 def test_migrate_run(job_store):


### PR DESCRIPTION
~~Use `sync_wait` in `test_listen_for_jobs_run` and `test_wait_for_jobs` and get rid of the "coroutine 'xxxx' was never awaited" warnings in the test output.~~

Make `test_listen_for_jobs_run` and `test_wait_for_jobs async` and get rid of the "coroutine 'xxxx' was never awaited" warnings in the test output.

Fixes #127.

### Successful PR Checklist:
- [ ] Tests
- [X] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation)) **Not relevant**
- [X] Had a good time contributing? (if not, feel free to give some feedback)
