### PR TITLE
Fix bug in get_connection

### DIFF
--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -24,6 +24,10 @@ def get_connection(dsn="", **kwargs) -> Awaitable[aiopg.Connection]:
     return aiopg.connect(dsn=dsn, **kwargs)
 
 
+def connection_is_open(connection: aiopg.Connection) -> bool:
+    return not connection.closed
+
+
 async def execute_query(
     connection: aiopg.Connection, query: str, **arguments: Any
 ) -> None:
@@ -97,7 +101,7 @@ class PostgresJobStore(store.BaseJobStore):
         self.socket_timeout = socket_timeout
 
     async def get_connection(self):
-        if not self._connection:
+        if not self._connection or not connection_is_open(self._connection):
             self._connection = await get_connection(**self._connection_parameters)
         return self._connection
 

--- a/tests/integration/test_pg_store.py
+++ b/tests/integration/test_pg_store.py
@@ -419,3 +419,19 @@ async def test_close_connection_no_connection(pg_job_store):
 async def test_stop_no_connection(pg_job_store):
     pg_job_store.stop()
     # Well we didn't crash. Great.
+
+
+async def test_get_connection_called_twice(pg_job_store):
+    conn1 = await pg_job_store.get_connection()
+    assert not conn1.closed
+    conn2 = await pg_job_store.get_connection()
+    assert conn2 is conn1
+
+
+async def test_get_connection_after_close(pg_job_store):
+    conn1 = await pg_job_store.get_connection()
+    assert not conn1.closed
+    await pg_job_store.close_connection()
+    conn2 = await pg_job_store.get_connection()
+    assert not conn2.closed
+    assert conn2 is not conn1


### PR DESCRIPTION
This fixes a bug in `get_connection` where `get_connection` may return a closed connection.

@ewjoachim please confirm that `get_connection` is meant to return an open connection, and that `get_connection` is supposed to return a new connection when the previous one was closed.

### Successful PR Checklist:
- [X] Tests
- [X] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation)) **not relevant**
- [X] Had a good time contributing? (if not, feel free to give some feedback)
