### PR TITLE
Custom JSON encoders and decoders

### DIFF
--- a/docs/howto/custom_json_encoder_decoder.rst
+++ b/docs/howto/custom_json_encoder_decoder.rst
@@ -1,0 +1,54 @@
+Define custom JSON encoders and decoders
+----------------------------------------
+
+When calling ``mytask.defer()`` to create a job, the task arguments are serialized into
+a JSON string for storing into the Postgres database.
+
+And after fetching a job from the database Procrastinate workers need to deserialize
+the task arguments before calling the task.
+
+By default Procrastinate relies on the JSON dumps and loads functions used by psycopg2.
+(See the `psycopg2 documentation`_.) Procrastinate makes it possible to specify custom
+encoders and decoders.
+
+Here is an example involving serializing/deserializing ``datetime`` objects::
+
+    import functools
+    import json
+
+    from procrastinate import App, PostgresJobStore
+
+    # Function used for encoding datetime objects
+    def encode(obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        raise TypeError()
+
+
+    # Function used for decoding datetime objects
+    def decode(dict_):
+        if "dt" in dict_:
+            dict_["dt"] = datetime.datetime.fromisoformat(dict_["dt"])
+        return dict_
+
+    json_dumps = functools.partial(json.dumps, default=encode)
+    json_loads = functools.partial(json.loads, object_hook=decode)
+
+    app = App(job_store=PostgresJobStore(json_dumps=json_dumps, json_loads=json_loads))
+
+In this example the custom JSON dumps and loads functions are based on the standard
+``json`` module's ``dumps`` and ``loads`` functions, with specific ``default`` and
+``object_hook`` for serializing and deserializing ``datetime`` objects, respectively.
+(See the `Python 3 json documentation`_ for more detail.)
+
+This mechanism even makes it possible to use a different JSON implemation than ``json``,
+such as `UltraJSON`_ for example.
+
+Also, if your encoding function starts resembling a long list of ``if isinstance``
+calls, you may want to have a look at ``functools.singledispatch`` for a cleaner
+way. (See the `Python 3 functools documentation`_ for more detail.)
+
+.. _psycopg2 documentation: https://www.psycopg.org/docs/extras.html#json-adaptation
+.. _Python 3 json documentation: https://docs.python.org/3/library/json.html
+.. _UltraJSON: https://pypi.org/project/ujson/
+.. _Python 3 functools documentation: https://docs.python.org/3/library/functools.html#functools.singledispatch

--- a/docs/howto_index.rst
+++ b/docs/howto_index.rst
@@ -24,3 +24,4 @@ How-to...
     howto/deployment
     howto/monitoring
     howto/remove_old_jobs
+    howto/custom_json_encoder_decoder

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import logging
 import os
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 
 import click
 import pendulum
@@ -155,7 +155,9 @@ def defer(
     JSON_ARGS should be a json object (a.k.a dictionnary) with the job parameters
     """
     # Loading json args
-    args = load_json_args(json_args=json_args)
+    args = load_json_args(
+        json_args=json_args, json_loads=app.job_store.json_loads or json.loads
+    )
 
     if at is not None and in_ is not None:
         raise click.UsageError("Cannot use both --at and --in")
@@ -189,12 +191,12 @@ def filter_none(dictionnary: Dict) -> Dict:
     return {key: value for key, value in dictionnary.items() if value is not None}
 
 
-def load_json_args(json_args) -> types.JSONDict:
+def load_json_args(json_args: str, json_loads: Callable) -> types.JSONDict:
     if json_args is None:
         return {}
     else:
         try:
-            args = json.loads(json_args)
+            args = json_loads(json_args)
             assert type(args) == dict
         except Exception:
             raise click.BadArgumentUsage(

--- a/procrastinate/store.py
+++ b/procrastinate/store.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from procrastinate import jobs, sql
 
@@ -14,6 +14,9 @@ def get_channel_for_queues(queues: Optional[Iterable[str]] = None) -> Iterable[s
 
 
 class BaseJobStore:
+    json_dumps: Optional[Callable] = None
+    json_loads: Optional[Callable] = None
+
     async def wait_for_jobs(self):
         raise NotImplementedError
 

--- a/tests/acceptance/param.py
+++ b/tests/acceptance/param.py
@@ -1,0 +1,8 @@
+class Param:
+    p: int
+
+    def __init__(self, p: str):
+        self.p = p
+
+    def __add__(self, other: "Param"):
+        return self.p + other.p

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 
 import click
@@ -66,13 +67,13 @@ def test_main(mocker):
     "input, output", [(None, {}), ("{}", {}), ("""{"a": "b"}""", {"a": "b"})]
 )
 def test_load_json_args(input, output):
-    assert cli.load_json_args(input) == output
+    assert cli.load_json_args(input, json.loads) == output
 
 
 @pytest.mark.parametrize("input", ["", "{", "[1, 2, 3]", '"yay"'])
 def test_load_json_args_error(input):
     with pytest.raises(click.BadArgumentUsage):
-        assert cli.load_json_args(input)
+        assert cli.load_json_args(input, json.loads)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cf. #99 (and #108 for the preliminary work on this).

This PR makes it possible for the user to provide custom JSON encoders and decoders.

The custom encoder and decoder are provided as JSON `dumps` and `loads` functions on the `App` object.

Here's an example dealing with `datetime` objects:

```py
import functools
import json

from procrastinate import App, PostgresJobStore

# Function used for encoding datetime objects
def encode(obj):
    if isinstance(obj, datetime.datetime):
        return obj.isoformat()
    raise TypeError()

dumps = functools.partial(json.dumps, default=encode)

# Function used for decoding datetime objects
def decode(dict_):
    if "dt" in dict_:
        dict_["dt"] = datetime.datetime.fromisoformat(dict_["dt"])
    return dict_

loads = functools.partial(json.loads, object_hook=decode)

app = App(job_store=PostgresJobStore(), dumps=dumps, loads=loads)
```

I think the approach provides a maximum of flexibility to the users. They can use the `json` module the way they want. They can even use a different JSON implementation than `json`, such as [UltraJSON](https://pypi.org/project/ujson/), if they want to.

I am creating this PR for discussion. The code in my branch (attached to this PR) basically works and is tested, although there's still work to do (typing, documentation, more tests maybe, etc.).

Any feedback?

### Successful PR Checklist:
- [x] Tests
- [x] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (if not, feel free to give some feedback)
