### PR TITLE
Add name attribute to workers and print it in the logs

### DIFF
--- a/docs/howto/worker.rst
+++ b/docs/howto/worker.rst
@@ -5,10 +5,11 @@ You can either go towards the CLI route with:
 
 .. code-block:: console
 
-    $ procrastinate --verbose --app=dotted.path.to.app worker [queue [...]]
+    $ procrastinate --verbose --app=dotted.path.to.app worker [--name=worker-name] [queue [...]]
 
 or, identically, use the code way::
 
-    app.run_worker(queues=["queue", ...])
+    app.run_worker(queues=["queue", ...], name="worker-name")
 
 In both cases, not specifying queues will tell Procrastinate to listen to every queue.
+Naming the worker is optional.

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -157,10 +157,12 @@ class App:
 
         return tasks.configure_task(name=name, job_store=self.job_store, **kwargs)
 
-    def _worker(self, queues: Optional[Iterable[str]] = None) -> "worker.Worker":
+    def _worker(
+        self, queues: Optional[Iterable[str]] = None, name: Optional[str] = None
+    ) -> "worker.Worker":
         from procrastinate import worker
 
-        return worker.Worker(app=self, queues=queues)
+        return worker.Worker(app=self, queues=queues, name=name)
 
     @functools.lru_cache(maxsize=1)
     def perform_import_paths(self):
@@ -175,7 +177,10 @@ class App:
         )
 
     async def run_worker_async(
-        self, queues: Optional[Iterable[str]] = None, only_once: bool = False
+        self,
+        queues: Optional[Iterable[str]] = None,
+        name: Optional[str] = None,
+        only_once: bool = False,
     ) -> None:
         """
         Run a worker. This worker will run in the foreground
@@ -193,7 +198,7 @@ class App:
             defined tasks. This function will return when the
             listened queues are empty.
         """
-        worker = self._worker(queues=queues)
+        worker = self._worker(queues=queues, name=name)
         if only_once:
             try:
                 await worker.process_jobs_once()

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -113,14 +113,15 @@ def close_connection(procrastinate_app: procrastinate.App, *args, **kwargs):
 @click.pass_obj
 @handle_errors()
 @click.argument("queue", nargs=-1)
-def worker(app: procrastinate.App, queue: Iterable[str]):
+@click.option("--name", help="Name of the worker")
+def worker(app: procrastinate.App, queue: Iterable[str], name: Optional[str]):
     """
     Launch a worker, listening on the given queues (or all queues).
     """
     queues = list(queue) or None
     queue_names = ", ".join(queues) if queues else "all queues"
     click.echo(f"Launching a worker on {queue_names}")
-    app.run_worker(queues=queues)  # type: ignore
+    app.run_worker(queues=queues, name=name)  # type: ignore
 
 
 @cli.command()

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -14,9 +14,11 @@ class Worker:
         app: app.App,
         queues: Optional[Iterable[str]] = None,
         import_paths: Optional[Iterable[str]] = None,
+        name: Optional[str] = None,
     ):
         self.app = app
         self.queues = queues
+        self.name = name
         self.stop_requested = False
         # Handling the info about the currently running task.
         self.log_context: types.JSONDict = {}
@@ -24,6 +26,11 @@ class Worker:
 
         self.app.perform_import_paths()
         self.job_store = self.app.job_store
+
+        if name:
+            self.logger = logger.getChild(name)
+        else:
+            self.logger = logger
 
     async def run(self) -> None:
         await self.job_store.listen_for_jobs(queues=self.queues)
@@ -36,13 +43,13 @@ class Worker:
                 except exceptions.StopRequested:
                     break
                 except exceptions.NoMoreJobs:
-                    logger.debug(
+                    self.logger.debug(
                         "Waiting for new jobs", extra={"action": "waiting_for_jobs"}
                     )
 
                 await self.job_store.wait_for_jobs()
 
-        logger.debug("Stopped worker", extra={"action": "stopped_worker"})
+        self.logger.debug("Stopped worker", extra={"action": "stopped_worker"})
 
     async def process_jobs_once(self) -> NoReturn:
         while True:
@@ -56,7 +63,7 @@ class Worker:
             raise exceptions.NoMoreJobs
 
         log_context = {"job": job.get_context()}
-        logger.debug(
+        self.logger.debug(
             "Loaded job info, about to start job",
             extra={"action": "loaded_job_info", **log_context},
         )
@@ -72,7 +79,7 @@ class Worker:
         except exceptions.JobError:
             pass
         except exceptions.TaskNotFound as exc:
-            logger.exception(
+            self.logger.exception(
                 f"Task was not found: {exc}",
                 extra={"action": "task_not_found", "exception": str(exc)},
             )
@@ -80,7 +87,7 @@ class Worker:
             await self.job_store.finish_job(
                 job=job, status=status, scheduled_at=next_attempt_scheduled_at
             )
-            logger.debug(
+            self.logger.debug(
                 "Acknowledged job completion",
                 extra={"action": "finish_task", "status": status, **log_context},
             )
@@ -107,7 +114,7 @@ class Worker:
             self.known_missing_tasks.add(task_name)
             raise
 
-        logger.warning(
+        self.logger.warning(
             f"Task at {task_name} was not registered, it's been loaded dynamically.",
             extra={"action": "load_dynamic_task", "task_name": task_name},
         )
@@ -127,7 +134,9 @@ class Worker:
         log_context = self.log_context = job.get_context()
         log_context["start_timestamp"] = time.time()
 
-        logger.info("Starting job", extra={"action": "start_job", "job": log_context})
+        self.logger.info(
+            "Starting job", extra={"action": "start_job", "job": log_context}
+        )
         try:
             task_result = task(**job.task_kwargs)
             if asyncio.iscoroutine(task_result):
@@ -154,7 +163,7 @@ class Worker:
             end_time = log_context["end_timestamp"] = time.time()
             log_context["duration_seconds"] = end_time - start_time
             extra = {"action": log_action, "job": log_context, "result": task_result}
-            logger.log(log_level, log_title, extra=extra, exc_info=exc_info)
+            self.logger.log(log_level, log_title, extra=extra, exc_info=exc_info)
 
     def stop(
         self,
@@ -165,7 +174,7 @@ class Worker:
         log_context = self.log_context
         self.job_store.stop()
 
-        logger.info(
+        self.logger.info(
             "Stop requested, waiting for current job to finish",
             extra={"action": "stopping_worker", "job": log_context},
         )

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -34,11 +34,11 @@ def test_version(entrypoint):
 
 def test_worker(entrypoint, click_app, mocker):
     click_app.run_worker = mocker.MagicMock()
-    result = entrypoint("-a yay worker a b")
+    result = entrypoint("-a yay worker a b --name=w1")
 
     assert result.output.strip() == "Launching a worker on a, b"
     assert result.exit_code == 0
-    click_app.run_worker.assert_called_once_with(queues=["a", "b"])
+    click_app.run_worker.assert_called_once_with(queues=["a", "b"], name="w1")
 
 
 def test_migrate(entrypoint, click_app, mocker, job_store):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -66,9 +66,9 @@ def test_app_register_queue_already_exists(app):
 def test_app_worker(app, mocker):
     Worker = mocker.patch("procrastinate.worker.Worker")
 
-    app._worker(queues=["yay"])
+    app._worker(queues=["yay"], name="w1")
 
-    Worker.assert_called_once_with(queues=["yay"], app=app)
+    Worker.assert_called_once_with(queues=["yay"], app=app, name="w1")
 
 
 def test_app_run_worker(app, mocker):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -184,6 +184,7 @@ async def test_run_job_log_name(caplog, app, job_store):
     await test_worker.run_job(job)
     assert len(caplog.records) == 2
     assert all(record.name.endswith("worker") for record in caplog.records)
+    assert all(not hasattr(record, "worker_name") for record in caplog.records)
 
     caplog.clear()
 
@@ -191,6 +192,7 @@ async def test_run_job_log_name(caplog, app, job_store):
     await test_worker.run_job(job)
     assert len(caplog.records) == 2
     assert all(record.name.endswith("worker.w1") for record in caplog.records)
+    assert all(record.worker_name == "w1" for record in caplog.records)
 
 
 async def test_run_job_error(app, job_store):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -166,6 +166,33 @@ async def test_run_job_log_result(caplog, app, job_store):
     assert record.result == 12
 
 
+async def test_run_job_log_name(caplog, app, job_store):
+    caplog.set_level("INFO")
+
+    def task_func():
+        pass
+
+    task = tasks.Task(task_func, app=app, queue="yay", name="job")
+
+    app.tasks = {"task_func": task}
+
+    job = jobs.Job(
+        id=16, task_kwargs={}, lock="sherlock", task_name="task_func", queue="yay",
+    )
+
+    test_worker = worker.Worker(app, queues=["yay"])
+    await test_worker.run_job(job)
+    assert len(caplog.records) == 2
+    assert all(record.name.endswith("worker") for record in caplog.records)
+
+    caplog.clear()
+
+    test_worker = worker.Worker(app, queues=["yay"], name="w1")
+    await test_worker.run_job(job)
+    assert len(caplog.records) == 2
+    assert all(record.name.endswith("worker.w1") for record in caplog.records)
+
+
 async def test_run_job_error(app, job_store):
     def job(a, b):  # pylint: disable=unused-argument
         raise ValueError("nope")


### PR DESCRIPTION
It would be great, when running multiple workers and joining all the logs, to identify which worker produces which log.
The purpose of this PR is to add an optional name parameter to workers, and use this name to format logs.

### Successful PR Checklist:
- [x] Tests
- [x] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (if not, feel free to give some feedback)
