### PR TITLE
Don't set enable_json and enable_hstore to False

### DIFF
--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -16,11 +16,6 @@ def wrap_json(arguments: Dict[str, Any]):
 
 
 def get_connection(dsn="", **kwargs) -> Awaitable[aiopg.Connection]:
-    # tell aiopg not to register adapters for hstore & json by default, as
-    # those are registered at the module level and could overwrite previously
-    # defined adapters
-    kwargs.setdefault("enable_json", False)
-    kwargs.setdefault("enable_hstore", False)
     return aiopg.connect(dsn=dsn, **kwargs)
 
 


### PR DESCRIPTION
Don't set `enable_json` and `enable_hstore` to `False` when calling `aiopg.connect`.

aiopg does `register_default_json(self._conn)`, so the registration of the json typecaster only applies to the connection being created.  And with Procrastinate creating its own connections there's no risk of overriding global application settings.

Cf. #113 

### Successful PR Checklist:
- [ ] Tests
- [X] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation)) **Not relevant**
- [X] Had a good time contributing? (if not, feel free to give some feedback)
