### PR TITLE
Set enable_uuid to False when calling aiopg.connect

### DIFF
--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -16,11 +16,12 @@ def wrap_json(arguments: Dict[str, Any]):
 
 
 def get_connection(dsn="", **kwargs) -> Awaitable[aiopg.Connection]:
-    # tell aiopg not to register adapters for hstore & json by default, as
+    # tell aiopg not to register adapters for json, hstore and uuid by default, as
     # those are registered at the module level and could overwrite previously
     # defined adapters
     kwargs.setdefault("enable_json", False)
     kwargs.setdefault("enable_hstore", False)
+    kwargs.setdefault("enable_uuid", False)
     return aiopg.connect(dsn=dsn, **kwargs)
 
 

--- a/tests/integration/test_pg_store.py
+++ b/tests/integration/test_pg_store.py
@@ -435,3 +435,9 @@ async def test_get_connection_after_close(pg_job_store):
     conn2 = await pg_job_store.get_connection()
     assert not conn2.closed
     assert conn2 is not conn1
+
+
+async def test_get_connection_no_psycopg2_adapter_registration(pg_job_store, mocker):
+    register_adapter = mocker.patch("psycopg2.extensions.register_adapter")
+    await pg_job_store.get_connection()
+    assert not register_adapter.called


### PR DESCRIPTION
This PR follows up on #113 and #133.

As discussed in #133 the psycopg2.extras `register_hstore` and `register_uuid` functions call `psycopg2.extensions.register_adapter` which register adapter globally. We already set `enable_hstore` to `False` to prevent the global registration of the hstore adapter. This PR does the same for uuid. This PR also adds a test verifying that calling `get_connection` doesn't lead global adapter registrations.

### Successful PR Checklist:
- [X] Tests
- [X] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation)) **not relevant**
- [X] Had a good time contributing? (if not, feel free to give some feedback)
