### PR TITLE
Remove the procrastinate_jobs.started_at column

### DIFF
--- a/docs/howto/custom_json_encoder_decoder.rst
+++ b/docs/howto/custom_json_encoder_decoder.rst
@@ -2,7 +2,7 @@ Define custom JSON encoders and decoders
 ----------------------------------------
 
 When calling ``mytask.defer()`` to create a job, the task arguments are serialized into
-a JSON string for storing into the Postgres database.
+a JSON string for storing into the PostgreSQL database.
 
 And after fetching a job from the database Procrastinate workers need to deserialize
 the task arguments before calling the task.
@@ -41,8 +41,8 @@ In this example the custom JSON dumps and loads functions are based on the stand
 ``object_hook`` for serializing and deserializing ``datetime`` objects, respectively.
 (See the `Python 3 json documentation`_ for more detail.)
 
-This mechanism even makes it possible to use a different JSON implemation than ``json``,
-such as `UltraJSON`_ for example.
+This mechanism even makes it possible to use a different JSON implementation than
+``json``, such as `UltraJSON`_ for example.
 
 Also, if your encoding function starts resembling a long list of ``if isinstance``
 calls, you may want to have a look at ``functools.singledispatch`` for a cleaner

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -5,12 +5,15 @@ asynchronicity
 backend
 backoff
 builtin
+Changelog
 codebase
 codebases
 coroutine
 coroutines
 cron
 crons
+deserialize
+deserializing
 Dramatiq
 enqueued
 formatters
@@ -20,3 +23,4 @@ middleware
 quickstart
 reimplement
 sync
+Travis

--- a/docs/sphinxext/changelog.py
+++ b/docs/sphinxext/changelog.py
@@ -25,7 +25,9 @@ class ChangelogDirective(Directive):
             par = nodes.paragraph()
             par += nodes.Text("(Changelog not built because ")
             par += nodes.literal("", "changelog_github_token")
-            par += nodes.Text(" parameter is missing in conf.py)")
+            par += nodes.Text(" parameter is missing in ")
+            par += nodes.literal("", "conf.py")
+            par += nodes.Text(")")
             return [par]
 
         owner_repo = self.extract_github_repo_name(self.options["github"])

--- a/procrastinate/migration.py
+++ b/procrastinate/migration.py
@@ -6,7 +6,7 @@ from procrastinate import sql, utils
 
 @utils.add_sync_api
 class Migrator:
-    version = "1.0.0"
+    version = "1.1.0"
 
     def __init__(self, connector: connector_module.BaseConnector):
 

--- a/procrastinate/migration.py
+++ b/procrastinate/migration.py
@@ -6,7 +6,7 @@ from procrastinate import sql, utils
 
 @utils.add_sync_api
 class Migrator:
-    version = "0.2.1"
+    version = "1.0.0"
 
     def __init__(self, connector: connector_module.BaseConnector):
 

--- a/procrastinate/sql/migrations/delta_1.1.0_drop_started_at.sql
+++ b/procrastinate/sql/migrations/delta_1.1.0_drop_started_at.sql
@@ -1,0 +1,34 @@
+CREATE OR REPLACE FUNCTION procrastinate_fetch_job(target_queue_names character varying[]) RETURNS procrastinate_jobs
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+	found_jobs procrastinate_jobs;
+BEGIN
+	WITH potential_job AS (
+		SELECT procrastinate_jobs.*
+			FROM procrastinate_jobs
+			LEFT JOIN procrastinate_job_locks ON procrastinate_job_locks.object = procrastinate_jobs.lock
+			WHERE (target_queue_names IS NULL OR queue_name = ANY( target_queue_names ))
+			  AND procrastinate_job_locks.object IS NULL
+			  AND status = 'todo'
+			  AND (scheduled_at IS NULL OR scheduled_at <= now())
+            ORDER BY id ASC
+			FOR UPDATE OF procrastinate_jobs SKIP LOCKED LIMIT 1
+	), lock_object AS (
+		INSERT INTO procrastinate_job_locks
+			SELECT lock FROM potential_job
+            ON CONFLICT DO NOTHING
+            RETURNING object
+	)
+	UPDATE procrastinate_jobs
+		SET status = 'doing'
+		FROM potential_job, lock_object
+        WHERE lock_object.object IS NOT NULL
+		AND procrastinate_jobs.id = potential_job.id
+		RETURNING * INTO found_jobs;
+
+	RETURN found_jobs;
+END;
+$$;
+
+ALTER TABLE procrastinate_jobs DROP COLUMN started_at;

--- a/procrastinate/sql/structure.sql
+++ b/procrastinate/sql/structure.sql
@@ -1,3 +1,5 @@
+-- Schema version 1.0.0
+
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 CREATE TABLE IF NOT EXISTS procrastinate_version (

--- a/procrastinate/sql/structure.sql
+++ b/procrastinate/sql/structure.sql
@@ -1,4 +1,4 @@
--- Schema version 1.0.0
+-- Schema version 1.1.0
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
@@ -34,7 +34,6 @@ CREATE TABLE procrastinate_jobs (
     args jsonb DEFAULT '{}' NOT NULL,
     status procrastinate_job_status DEFAULT 'todo'::procrastinate_job_status NOT NULL,
     scheduled_at timestamp with time zone NULL,
-    started_at timestamp with time zone NULL,
     attempts integer DEFAULT 0 NOT NULL
 );
 
@@ -72,8 +71,7 @@ BEGIN
             RETURNING object
 	)
 	UPDATE procrastinate_jobs
-		SET status = 'doing',
-            started_at = NOW()
+		SET status = 'doing'
 		FROM potential_job, lock_object
         WHERE lock_object.object IS NOT NULL
 		AND procrastinate_jobs.id = potential_job.id

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -86,7 +86,6 @@ class InMemoryConnector(connector.BaseConnector):
             "args": args,
             "status": "todo",
             "scheduled_at": scheduled_at,
-            "started_at": None,
             "attempts": 0,
         }
         self.events[id] = []
@@ -121,7 +120,6 @@ class InMemoryConnector(connector.BaseConnector):
                 and job["lock"] not in self.current_locks
             ):
                 job["status"] = "doing"
-                job["started_at"] = pendulum.now()
                 self.events[job["id"]].append({"type": "started", "at": pendulum.now()})
 
                 return job
@@ -149,7 +147,8 @@ class InMemoryConnector(connector.BaseConnector):
             job
             for job in self.jobs.values()
             if job["status"] == "doing"
-            and job["started_at"] < pendulum.now().subtract(seconds=nb_seconds)
+            and self.events[job["id"]][-1]["at"]
+            < pendulum.now().subtract(seconds=nb_seconds)
             and queue in (job["queue_name"], None)
             and task_name in (job["task_name"], None)
         )

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -146,7 +146,6 @@ def test_defer(entrypoint, click_app, connector):
             "lock": "sherlock",
             "queue_name": "default",
             "scheduled_at": None,
-            "started_at": None,
             "status": "todo",
             "task_name": "hello",
         }
@@ -167,7 +166,6 @@ def test_defer_unknown(entrypoint, click_app, connector):
             "lock": "sherlock",
             "queue_name": "default",
             "scheduled_at": None,
-            "started_at": None,
             "status": "todo",
             "task_name": "hello",
         }

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -55,7 +55,7 @@ def test_migrate(entrypoint, click_app, mocker, job_store):
 def test_migrate_text(entrypoint):
     result = entrypoint("migrate --text")
 
-    assert result.output.startswith("CREATE")
+    assert result.output.startswith("-- Schema version ")
     assert result.exit_code == 0
 
 

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -53,7 +53,6 @@ def test_job_deferrer_defer(job_store, connector):
             "lock": "sher",
             "queue_name": "marsupilami",
             "scheduled_at": None,
-            "started_at": None,
             "status": "todo",
             "task_name": "mytask",
         }
@@ -80,7 +79,6 @@ async def test_job_deferrer_defer_async(job_store, connector):
             "lock": "sher",
             "queue_name": "marsupilami",
             "scheduled_at": None,
-            "started_at": None,
             "status": "todo",
             "task_name": "mytask",
         }

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -4,7 +4,7 @@ from procrastinate import sql
 
 
 def test_get_migration_queries(app):
-    assert app.migrator.get_migration_queries().startswith("CREATE")
+    assert app.migrator.get_migration_queries().startswith("-- Schema version ")
 
 
 def test_migrate(app, connector):

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -19,7 +19,6 @@ async def test_store_defer(job_store, job_factory, connector):
             "lock": None,
             "queue_name": "queue",
             "scheduled_at": None,
-            "started_at": None,
             "status": "todo",
             "task_name": "bla",
         }
@@ -46,7 +45,7 @@ async def test_get_stalled_jobs_stalled(job_store, job_factory, connector):
     job = job_factory(id=1)
     await job_store.defer_job(job=job)
     await job_store.fetch_job(queues=None)
-    connector.jobs[1]["started_at"] = pendulum.datetime(2000, 1, 1)
+    connector.events[1][-1]["at"] = pendulum.datetime(2000, 1, 1)
     assert await job_store.get_stalled_jobs(nb_seconds=1000) == [job]
 
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -34,7 +34,6 @@ async def test_task_defer_async(app, connector):
             "args": {"c": 3},
             "status": "todo",
             "scheduled_at": None,
-            "started_at": None,
             "attempts": 0,
         }
     }

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -71,7 +71,6 @@ def test_defer_job_one(connector):
             "args": {"a": "b"},
             "status": "todo",
             "scheduled_at": None,
-            "started_at": None,
             "attempts": 0,
         }
     }
@@ -102,7 +101,6 @@ def test_select_stalled_jobs_all(connector):
         1: {
             "id": 1,
             "status": "succeeded",
-            "started_at": pendulum.datetime(2000, 1, 1),
             "queue_name": "marsupilami",
             "task_name": "mytask",
         },
@@ -110,7 +108,6 @@ def test_select_stalled_jobs_all(connector):
         2: {
             "id": 2,
             "status": "doing",
-            "started_at": pendulum.datetime(2000, 1, 1),
             "queue_name": "other_queue",
             "task_name": "mytask",
         },
@@ -118,15 +115,13 @@ def test_select_stalled_jobs_all(connector):
         3: {
             "id": 3,
             "status": "doing",
-            "started_at": pendulum.datetime(2000, 1, 1),
             "queue_name": "marsupilami",
             "task_name": "my_other_task",
         },
-        # This one because  it's not stalled
+        # This one because it's not stalled
         4: {
             "id": 4,
             "status": "doing",
-            "started_at": pendulum.datetime(2100, 1, 1),
             "queue_name": "marsupilami",
             "task_name": "mytask",
         },
@@ -134,7 +129,6 @@ def test_select_stalled_jobs_all(connector):
         5: {
             "id": 5,
             "status": "doing",
-            "started_at": pendulum.datetime(2000, 1, 1),
             "queue_name": "marsupilami",
             "task_name": "mytask",
         },
@@ -142,10 +136,17 @@ def test_select_stalled_jobs_all(connector):
         6: {
             "id": 6,
             "status": "doing",
-            "started_at": pendulum.datetime(2000, 1, 1),
             "queue_name": "marsupilami",
             "task_name": "mytask",
         },
+    }
+    connector.events = {
+        1: [{"at": pendulum.datetime(2000, 1, 1)}],
+        2: [{"at": pendulum.datetime(2000, 1, 1)}],
+        3: [{"at": pendulum.datetime(2000, 1, 1)}],
+        4: [{"at": pendulum.datetime(2100, 1, 1)}],
+        5: [{"at": pendulum.datetime(2000, 1, 1)}],
+        6: [{"at": pendulum.datetime(2000, 1, 1)}],
     }
 
     results = connector.select_stalled_jobs_all(


### PR DESCRIPTION
Closes #143 

This PR removes the unneeded `procrastinate_jobs.started_at` column. The `select_stalled_jobs`, which is the only user of that column, is rewritten in terms of a JOIN between `procrastinate_jobs` and `procrastinate_events`.

TODO with a separate PR: document how to use Pum to do database migrations.

### Successful PR Checklist:
- [x] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation)) **not relevant** + I propose to add an "Use Pum for migrations" How-to section with a separate PR
- [x] Had a good time contributing? (if not, feel free to give some feedback)
