### PR TITLE
(Deprecated PR) Use a pool instead of a single connection, and reorganize the worker around that

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -17,10 +17,14 @@ are accessible through :py:attr:`App.builtin_tasks`:
     app.builtin_tasks["remove_old_jobs"].defer(max_hours=72)
 
 
-Job stores
+Connectors
 ----------
 
+.. This does not indicate that create_with_pool* is an async classmethod because of
+   https://github.com/sphinx-doc/sphinx/issues/7189
+
 .. autoclass:: procrastinate.PostgresConnector
+    :members: create_with_pool, create_with_pool_async, close, close_async
 
 .. autoclass:: procrastinate.testing.InMemoryConnector
     :members: reset

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -105,6 +105,10 @@ class PostgresConnector(connector.BaseConnector):
             Passed to aiopg. Default is :py:class:`psycopg2.extras.RealDictCursor`
             instead of standard cursor. There is no identified use case for changing
             this.
+        maxsize (int):
+            Passed to aiopg. Cannot be lower than 2, otherwise worker won't be
+            functionning normally (one connection for listen/notify, one for executing
+            tasks)
         """
         base_on_connect = kwargs.pop("on_connect", None)
 
@@ -123,6 +127,9 @@ class PostgresConnector(connector.BaseConnector):
             "cursor_factory": RealDictCursor,
         }
         defaults.update(kwargs)
+
+        if "maxsize" in kwargs:
+            kwargs["maxsize"] = max(2, kwargs["maxsize"])
 
         pool = await aiopg.create_pool(**defaults)
 

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -161,12 +161,11 @@ class PostgresConnector(connector.BaseConnector):
         )
 
 
-class PostgresJobStore(PostgresConnector):
-    def __init__(self, *args, **kwargs):
-        message = (
-            "Use procrastinate.PostgresConnector(...) "
-            "instead of procrastinate.PostgresJobStore(...), with the same arguments"
-        )
-        logger.warn(f"Deprecation Warning: {message}")
-        warnings.warn(DeprecationWarning(message))
-        super().__init__(*args, **kwargs)
+def PostgresJobStore(*args, **kwargs):
+    message = (
+        "Use procrastinate.PostgresConnector(...) "
+        "instead of procrastinate.PostgresJobStore(...), with the same arguments"
+    )
+    logger.warn(f"Deprecation Warning: {message}")
+    warnings.warn(DeprecationWarning(message))
+    return PostgresConnector.create_with_pool(*args, **kwargs)

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -108,7 +108,7 @@ class PostgresConnector(connector.BaseConnector):
         """
         base_on_connect = kwargs.pop("on_connect", None)
 
-        def on_connect(connection):
+        async def on_connect(connection):
             if base_on_connect:
                 base_on_connect(connection)
             if json_loads:

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -100,7 +100,7 @@ class PostgresConnector(connector.BaseConnector):
         maxsize (int):
             Passed to aiopg. Cannot be lower than 2, otherwise worker won't be
             functionning normally (one connection for listen/notify, one for executing
-            tasks)
+            tasks).
         """
         base_on_connect = kwargs.pop("on_connect", None)
 

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -65,7 +65,7 @@ class App:
             workers wait between each database job pull. Job activity will be pushed
             from the db to the worker, but in case the push mechanism fails somehow,
             workers will not stay idle longer than the number of seconds indicated by
-            this parameters.
+            this parameter.
             Raising this parameter can lower the rate of workers making queries to the
             database for requesting jobs.
         job_store:

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -237,6 +237,3 @@ class App:
     @property
     def health_check_runner(self) -> healthchecks.HealthCheckRunner:
         return healthchecks.HealthCheckRunner(connector=self.connector)
-
-    async def close_connection_async(self):
-        await self.connector.close_connection()

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -219,8 +219,7 @@ class App:
         """
         Run a worker. This worker will run in the foreground
         and the function will not return until the worker stops
-        (most probably when it receives a stop signal) (except if
-        `only_once` is True).
+        (most probably when it receives a stop signal).
 
         Parameters
         ----------

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Set
 
 from procrastinate import builtin_tasks
 from procrastinate import connector as connector_module
-from procrastinate import exceptions, healthchecks, jobs
+from procrastinate import healthchecks, jobs
 from procrastinate import retry as retry_module
 from procrastinate import schema, store, utils
 
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
     from procrastinate import tasks, worker
 
 logger = logging.getLogger(__name__)
+
+WORKER_TIMEOUT = 5.0  # seconds
 
 
 @utils.add_sync_api
@@ -35,7 +37,7 @@ class App:
         *,
         connector: Optional[connector_module.BaseConnector] = None,
         import_paths: Optional[Iterable[str]] = None,
-        worker_timeout: float = worker.WORKER_TIMEOUT,
+        worker_timeout: float = WORKER_TIMEOUT,
         # Just for backwards compatibility
         job_store: Optional[connector_module.BaseConnector] = None,
     ):

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -105,7 +105,7 @@ def cli(ctx: click.Context, app: str, **kwargs) -> None:
 @click.pass_obj
 def close_connection(procrastinate_app: procrastinate.App, *args, **kwargs):
     # There's an internal click param named app, we can't name our variable "app" too.
-    procrastinate_app.close_connection()  # type: ignore
+    procrastinate_app.connector.close()
 
 
 @cli.command()

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -7,7 +7,7 @@ class BaseConnector:
     json_dumps: Optional[Callable] = None
     json_loads: Optional[Callable] = None
 
-    async def close_connection(self) -> None:
+    async def close(self) -> None:
         pass
 
     async def execute_query(self, query: str, **arguments: Any) -> None:
@@ -22,10 +22,4 @@ class BaseConnector:
         raise NotImplementedError
 
     def make_dynamic_query(self, query: str, **identifiers: str) -> str:
-        raise NotImplementedError
-
-    async def wait_for_activity(self) -> None:
-        raise NotImplementedError
-
-    def interrupt_wait(self):
         raise NotImplementedError

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -1,6 +1,5 @@
-from typing import Any, Callable, Dict, List, Optional
-
-SOCKET_TIMEOUT = 5.0  # seconds
+import asyncio
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 
 class BaseConnector:
@@ -22,4 +21,9 @@ class BaseConnector:
         raise NotImplementedError
 
     def make_dynamic_query(self, query: str, **identifiers: str) -> str:
+        raise NotImplementedError
+
+    async def listen_notify(
+        self, event: asyncio.Event, channels: Iterable[str]
+    ) -> None:
         raise NotImplementedError

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -20,11 +20,3 @@ class LoadFromPathError(ImportError, ProcrastinateException):
 class JobRetry(ProcrastinateException):
     def __init__(self, scheduled_at: datetime.datetime):
         self.scheduled_at = scheduled_at
-
-
-class StopRequested(ProcrastinateException):
-    pass
-
-
-class NoMoreJobs(ProcrastinateException):
-    pass

--- a/procrastinate/signals.py
+++ b/procrastinate/signals.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 @contextmanager
 def on_stop(callback: Callable[[], None]):
-    print("yay")
     if threading.current_thread() is not threading.main_thread():
         logger.debug(
             "Skipping signal handling, because this is not the main thread",

--- a/procrastinate/signals.py
+++ b/procrastinate/signals.py
@@ -1,9 +1,8 @@
 import logging
-
 import signal
 import threading
-from contextlib import contextmanager
 import types
+from contextlib import contextmanager
 from typing import Callable
 
 logger = logging.getLogger(__name__)

--- a/procrastinate/store.py
+++ b/procrastinate/store.py
@@ -96,8 +96,14 @@ class JobStore:
         )
 
     async def listen_for_jobs(
-        self, *, event: asyncio.Event, queues: Optional[Iterable[str]] = None,
+        self,
+        *,
+        notify_event: asyncio.Event,
+        queues: Optional[Iterable[str]] = None,
+        listen_event: Optional[asyncio.Event] = None,
     ) -> None:
         await self.connector.listen_notify(
-            event=event, channels=get_channel_for_queues(queues=queues)
+            channels=get_channel_for_queues(queues=queues),
+            notify_event=notify_event,
+            listen_event=listen_event,
         )

--- a/procrastinate/store.py
+++ b/procrastinate/store.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 from typing import Iterable, Optional
 
@@ -94,11 +95,9 @@ class JobStore:
             scheduled_at=scheduled_at,
         )
 
-    async def listen_for_jobs(self, queues: Optional[Iterable[str]] = None) -> None:
-        for channel_name in get_channel_for_queues(queues=queues):
-
-            await self.connector.execute_query(
-                query=self.connector.make_dynamic_query(
-                    query=sql.queries["listen_queue"], channel_name=channel_name
-                )
-            )
+    async def listen_for_jobs(
+        self, *, event: asyncio.Event, queues: Optional[Iterable[str]] = None,
+    ) -> None:
+        await self.connector.listen_notify(
+            event=event, channels=get_channel_for_queues(queues=queues)
+        )

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -69,16 +69,21 @@ class InMemoryConnector(connector.BaseConnector):
         return query.format(**identifiers)
 
     async def listen_notify(
-        self, event: asyncio.Event, channels: Iterable[str]
+        self,
+        channels: Iterable[str],
+        notify_event: asyncio.Event,
+        listen_event: Optional[asyncio.Event],
     ) -> NoReturn:
         for channel_name in channels:
             query = self.make_dynamic_query(
                 query=sql.queries["listen_queue"], channel_name=channel_name
             )
             self.generic_execute(query, "run")
+        if listen_event:
+            listen_event.set()
         while True:
             await asyncio.sleep(0)
-            event.set()
+            notify_event.set()
 
     def stop(self) -> None:
         pass

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -1,8 +1,8 @@
 import asyncio
-import functools
 import importlib
 import logging
-from typing import Awaitable, Iterable, Type, TypeVar
+import types
+from typing import Any, Awaitable, Iterable, Type, TypeVar
 
 from procrastinate import exceptions
 
@@ -67,21 +67,35 @@ def wrap_one(cls: Type, attribute_name: str):
     if attribute_name.startswith("_") or not attribute_name.endswith(suffix):
         return
 
-    attribute = getattr(cls, attribute_name)
+    # Methods are descriptors so using getattr here will not give us the real method
+    cls_vars = vars(cls)
+    attribute = cls_vars[attribute_name]
+
+    # If method is a classmethod or staticmethod, its real function, that may be
+    # async, is stored in __func__.
+    wrapped = getattr(attribute, "__func__", attribute)
 
     # Keep only async def methods
-    if not asyncio.iscoroutinefunction(attribute):
+    if not asyncio.iscoroutinefunction(wrapped):
         return
 
     # Create a wrapper that will call the method in a run_until_complete
-    @functools.wraps(attribute)
-    def wrapper(self, *args, **kwargs):
-        awaitable = attribute(self, *args, **kwargs)
+    # @functools.wraps(attribute)
+    def wrapper(*args, **kwargs):
+        awaitable = wrapped(*args, **kwargs)
         return sync_await(awaitable=awaitable)
+
+    final_wrapper: Any
+    if isinstance(attribute, types.FunctionType):  # classic method
+        final_wrapper = wrapper
+    elif isinstance(attribute, classmethod):
+        final_wrapper = classmethod(wrapper)
+    elif isinstance(attribute, staticmethod):
+        final_wrapper = staticmethod(wrapper)
 
     # Save this new method on the class
     name = wrapper.__name__ = attribute_name[: -len(suffix)]
-    setattr(cls, name, wrapper)
+    setattr(cls, name, final_wrapper)
 
 
 def sync_await(awaitable: Awaitable[T]) -> T:

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -45,7 +45,9 @@ class Worker:
     async def run(self) -> None:
         notify_event = asyncio.Event()
         self.notify_task = asyncio.create_task(
-            self.job_store.listen_for_jobs(event=notify_event, queues=self.queues)
+            self.job_store.listen_for_jobs(
+                queues=self.queues, notify_event=notify_event
+            )
         )
 
         def stop() -> None:

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -17,7 +17,6 @@ class Worker:
         queues: Optional[Iterable[str]] = None,
         import_paths: Optional[Iterable[str]] = None,
         name: Optional[str] = None,
-        worker_count: int = 1,
         timeout: float = WORKER_TIMEOUT,
     ):
         self.app = app
@@ -28,6 +27,7 @@ class Worker:
         # Handling the info about the currently running task.
         self.known_missing_tasks: Set[str] = set()
 
+        # TODO: should be moved to the app
         self.app.perform_import_paths()
         self.job_store = self.app.job_store
 

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -7,8 +7,6 @@ from procrastinate import app, exceptions, jobs, signals, tasks, types
 
 logger = logging.getLogger(__name__)
 
-WORKER_TIMEOUT = 5.0  # seconds
-
 
 class Worker:
     def __init__(
@@ -17,7 +15,7 @@ class Worker:
         queues: Optional[Iterable[str]] = None,
         import_paths: Optional[Iterable[str]] = None,
         name: Optional[str] = None,
-        timeout: float = WORKER_TIMEOUT,
+        timeout: float = app.WORKER_TIMEOUT,
     ):
         self.app = app
         self.queues = queues
@@ -49,10 +47,7 @@ class Worker:
             self.job_store.listen_for_jobs(event=notify_event, queues=self.queues)
         )
 
-        def stop(
-            signum: Optional[signals.Signals] = None,
-            frame: Optional[signals.FrameType] = None,
-        ) -> None:
+        def stop() -> None:
             # Ensure worker will stop after finishing their task
             self.stop_requested = True
             # Ensure workers currently waiting are awakened

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -40,10 +40,11 @@ class Worker:
             self.worker_name = None
 
         self.current_job_context: Optional[Dict] = None
+        self.notify_task: Optional[asyncio.Task] = None
 
     async def run(self) -> None:
         notify_event = asyncio.Event()
-        notifier = asyncio.create_task(
+        self.notify_task = asyncio.create_task(
             self.job_store.listen_for_jobs(event=notify_event, queues=self.queues)
         )
 
@@ -53,7 +54,7 @@ class Worker:
             # Ensure workers currently waiting are awakened
             notify_event.set()
             # Stop the listen/notify task
-            notifier.cancel()
+            self.notify_task.cancel()
 
             extra: Dict[str, Any] = {
                 "action": "stopping_worker",

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -173,7 +173,11 @@ class Worker:
 
         self.logger.warning(
             f"Task at {task_name} was not registered, it's been loaded dynamically.",
-            extra={"action": "load_dynamic_task", "task_name": task_name},
+            extra={
+                "action": "load_dynamic_task",
+                "task_name": task_name,
+                **log_context,
+            },
         )
 
         self.app.tasks[task_name] = task

--- a/procrastinate_demo/__main__.py
+++ b/procrastinate_demo/__main__.py
@@ -16,7 +16,7 @@ def main():
     tasks.sleep.configure(lock="a").defer(i=4)
     tasks.random_fail.defer()
 
-    app.close_connection()
+    app.connector.close()
 
 
 if __name__ == "__main__":

--- a/procrastinate_demo/app.py
+++ b/procrastinate_demo/app.py
@@ -1,7 +1,7 @@
 import procrastinate
 
 app = procrastinate.App(
-    connector=procrastinate.PostgresConnector(
+    connector=procrastinate.PostgresConnector.create_with_pool(  # type: ignore
         dsn="postgresql://postgres@localhost/procrastinate"
     ),
     import_paths=["procrastinate_demo.tasks"],

--- a/tests/acceptance/app.py
+++ b/tests/acceptance/app.py
@@ -25,7 +25,7 @@ json_dumps = functools.partial(json.dumps, default=encode)
 json_loads = functools.partial(json.loads, object_hook=decode)
 
 app = procrastinate.App(
-    connector=procrastinate.PostgresConnector(
+    connector=procrastinate.PostgresConnector.create_with_pool(  # type: ignore
         json_dumps=json_dumps, json_loads=json_loads
     )
 )

--- a/tests/integration/test_aiopg_connector.py
+++ b/tests/integration/test_aiopg_connector.py
@@ -13,42 +13,25 @@ pytestmark = pytest.mark.asyncio
 async def pg_connector_factory(connection_params):
     connectors = []
 
-    def _(**kwargs):
+    async def _(**kwargs):
         connection_params.update(kwargs)
-        connector = aiopg_connector.PostgresConnector(**connection_params)
+        connector = await aiopg_connector.PostgresConnector.create_with_pool_async(
+            **connection_params
+        )
         connectors.append(connector)
         return connector
 
     yield _
     for connector in connectors:
-        await connector.close_connection()
+        await connector.close_async()
 
 
-async def test_get_connection(pg_connector, connection_params):
-    async with await pg_connector._get_connection() as connection:
-
+async def test_create_with_pool(connection_params):
+    connector = await aiopg_connector.PostgresConnector.create_with_pool_async(
+        **connection_params
+    )
+    async with connector._pool.acquire() as connection:
         assert connection.dsn == "dbname=" + connection_params["dbname"]
-
-
-async def test_get_connection_json_loads(pg_connector_factory, mocker):
-    json_loads = mocker.MagicMock()
-    register_default_jsonb = mocker.patch("psycopg2.extras.register_default_jsonb")
-    connector = pg_connector_factory(json_loads=json_loads)
-    async with await connector._get_connection() as connection:
-        register_default_jsonb.assert_called_with(connection.raw, loads=json_loads)
-
-
-async def test_get_connection_simultaneous(pg_connector):
-    # two coroutines doing _get_connection simultaneously
-    #
-    # the test fails because two separate connections are created if no lock is
-    # used in _get_connection
-
-    async def get_connection():
-        return await pg_connector._get_connection()
-
-    connections = await asyncio.gather(get_connection(), get_connection())
-    assert connections[0] is connections[1]
 
 
 @pytest.mark.parametrize(
@@ -72,7 +55,7 @@ async def test_execute_query_one_json_loads(
     query = "SELECT %(arg)s::jsonb as json"
     arg = {"a": "a", "b": NotJSONSerializableByDefault()}
     json_dumps = functools.partial(json.dumps, default=encode)
-    connector = pg_connector_factory(json_dumps=json_dumps)
+    connector = await pg_connector_factory(json_dumps=json_dumps)
     method = getattr(connector, method_name)
 
     result = await method(query, arg=arg)
@@ -101,8 +84,7 @@ async def test_execute_query(pg_connector):
 async def test_execute_query_simultaneous(pg_connector):
     # two coroutines doing execute_query simulteneously
     #
-    # the test fails because of a ResourceWarning error if the lock is not hold
-    # while creating the cursor on the connection
+    # the test may fail if the connector fails to properly parallelize connections
 
     async def query():
         await pg_connector.execute_query("SELECT 1")
@@ -113,39 +95,15 @@ async def test_execute_query_simultaneous(pg_connector):
         pytest.fail("ResourceWarning")
 
 
-async def test_close_connection(pg_connector):
-    await pg_connector._get_connection()
-    await pg_connector.close_connection()
-    assert pg_connector._connection.closed == 1
+async def test_close_async(pg_connector):
+    await pg_connector.execute_query("SELECT 1")
+    await pg_connector.close_async()
+    assert pg_connector._pool.closed is True
 
 
-async def test_close_connection_no_connection(pg_connector):
-    await pg_connector.close_connection()
-    # Well we didn't crash. Great.
-
-
-async def test_stop_no_connection(pg_connector):
-    pg_connector.interrupt_wait()
-    # Well we didn't crash. Great.
-
-
-async def test_get_connection_called_twice(pg_connector):
-    conn1 = await pg_connector._get_connection()
-    assert not conn1.closed
-    conn2 = await pg_connector._get_connection()
-    assert conn2 is conn1
-
-
-async def test_get_connection_after_close(pg_connector):
-    conn1 = await pg_connector._get_connection()
-    assert not conn1.closed
-    await pg_connector.close_connection()
-    conn2 = await pg_connector._get_connection()
-    assert not conn2.closed
-    assert conn2 is not conn1
-
-
-async def test_get_connection_no_psycopg2_adapter_registration(pg_connector, mocker):
+async def test_get_connection_no_psycopg2_adapter_registration(
+    connection_params, mocker
+):
     register_adapter = mocker.patch("psycopg2.extensions.register_adapter")
-    await pg_connector._get_connection()
+    await aiopg_connector.PostgresConnector.create_with_pool_async(**connection_params)
     assert not register_adapter.called

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -1,7 +1,6 @@
-import psycopg2
 import pytest
 
-from procrastinate import aiopg_connector, jobs
+from procrastinate import jobs
 from procrastinate.healthchecks import HealthCheckRunner
 
 pytestmark = pytest.mark.asyncio
@@ -21,14 +20,3 @@ async def test_get_status_count(checker):
     assert set(status_count.keys()) == set(jobs.Status)
     for known_status in jobs.Status:
         assert status_count[known_status] == 0
-
-
-@pytest.mark.parametrize(
-    "method", ["check_connection_async", "get_status_count_async"],
-)
-async def test_db_down(method):
-    bad_job_store = aiopg_connector.PostgresConnector(dsn="", dbname="a_bad_db_name")
-    checker = HealthCheckRunner(bad_job_store)
-
-    with pytest.raises(psycopg2.Error):
-        await getattr(checker, method)()

--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -7,13 +7,20 @@ from procrastinate import App, jobs, store
 
 
 @pytest.mark.asyncio
-async def test_wait_for_activity(pg_connector):
+async def test_listen_for_jobs(pg_connector):
     """
     Testing that a new job arriving in the queue interrupts the wait
     """
     pg_connector.socket_timeout = 2
     job_store = store.JobStore(connector=pg_connector)
-    await job_store.listen_for_jobs()
+
+    notify_event = asyncio.Event()
+    listen_event = asyncio.Event()
+
+    task = asyncio.create_task(
+        job_store.listen_for_jobs(notify_event=notify_event, listen_event=listen_event)
+    )
+    await listen_event.wait()
 
     async def defer_job():
         await asyncio.sleep(0.5)
@@ -22,10 +29,13 @@ async def test_wait_for_activity(pg_connector):
         )
 
     before = time.perf_counter()
-    await asyncio.gather(pg_connector.wait_for_activity(), defer_job())
+    await asyncio.gather(notify_event.wait(), defer_job())
     after = time.perf_counter()
 
-    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
+    # We can cancel the listen_notify asyncio task at this point
+    task.cancel()
+
+    # Test that we didn't wait more that 1 sec
     assert after - before < 1
 
     # We *did* create a job
@@ -33,25 +43,10 @@ async def test_wait_for_activity(pg_connector):
 
 
 @pytest.mark.asyncio
-async def test_wait_for_activity_timeout(pg_connector):
-    """
-    Testing that we timeout if nothing happens
-    """
-    pg_connector.socket_timeout = 0.01
-
-    before = time.perf_counter()
-    await pg_connector.wait_for_activity()
-    after = time.perf_counter()
-
-    assert after - before < 0.1
-
-
-@pytest.mark.asyncio
-async def test_wait_for_activity_stop_from_signal(pg_connector, kill_own_pid):
+async def test_listen_for_jobs_stop_from_signal(pg_connector, kill_own_pid):
     """
     Testing than ctrl+c interrupts the wait
     """
-    pg_connector.socket_timeout = 2
     app = App(connector=pg_connector)
 
     async def stop():
@@ -60,29 +55,6 @@ async def test_wait_for_activity_stop_from_signal(pg_connector, kill_own_pid):
 
     before = time.perf_counter()
     await asyncio.gather(app.run_worker_async(), stop())
-    after = time.perf_counter()
-
-    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
-    assert after - before < 1
-
-
-@pytest.mark.asyncio
-async def test_wait_for_activity_stop_from_pipe(pg_connector):
-    """
-    Testing than calling job_store.stop() interrupts the wait
-    """
-    # This is a sub-case from above but we never know.
-    pg_connector.socket_timeout = 2
-    job_store = store.JobStore(connector=pg_connector)
-
-    await job_store.listen_for_jobs()
-
-    async def stop():
-        await asyncio.sleep(0.5)
-        pg_connector.interrupt_wait()
-
-    before = time.perf_counter()
-    await asyncio.gather(pg_connector.wait_for_activity(), stop())
     after = time.perf_counter()
 
     # If we wait less than 1 sec, it means the wait didn't reach the timeout.

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -82,7 +82,9 @@ def test_app_worker(app, mocker):
 
     app._worker(queues=["yay"], name="w1")
 
-    Worker.assert_called_once_with(queues=["yay"], app=app, name="w1")
+    Worker.assert_called_once_with(
+        queues=["yay"], app=app, name="w1", timeout=app_module.WORKER_TIMEOUT
+    )
 
 
 def test_app_run_worker(app, mocker):
@@ -91,18 +93,6 @@ def test_app_run_worker(app, mocker):
     app.run_worker(queues=["yay"])
 
     run.assert_called_once_with()
-
-
-def test_app_run_worker_only_once(app):
-    @app.task
-    def yay():
-        pass
-
-    yay.defer()
-
-    assert len(app.connector.finished_jobs) == 0
-    app.run_worker(only_once=True)
-    assert len(app.connector.finished_jobs) == 1
 
 
 def test_from_path(mocker):

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -89,10 +89,12 @@ async def test_finish_job(job_store, job_factory, connector):
     ],
 )
 async def test_listen_for_jobs(job_store, connector, mocker, queues, channels):
-    notify_event = asyncio.Event()
+    listen_event = asyncio.Event()
     task = asyncio.create_task(
-        job_store.listen_for_jobs(event=notify_event, queues=queues)
+        job_store.listen_for_jobs(
+            notify_event=asyncio.Event(), queues=queues, listen_event=listen_event
+        )
     )
-    await notify_event.wait()
+    await listen_event.wait()
     task.cancel()
     assert connector.queries == [("listen_for_jobs", channel) for channel in channels]

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1,3 +1,4 @@
+import asyncio
 import pendulum
 import pytest
 
@@ -88,5 +89,10 @@ async def test_finish_job(job_store, job_factory, connector):
     ],
 )
 async def test_listen_for_jobs(job_store, connector, mocker, queues, channels):
-    await job_store.listen_for_jobs(queues)
+    notify_event = asyncio.Event()
+    task = asyncio.create_task(
+        job_store.listen_for_jobs(event=notify_event, queues=queues)
+    )
+    await notify_event.wait()
+    task.cancel()
     assert connector.queries == [("listen_for_jobs", channel) for channel in channels]

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -259,11 +259,13 @@ def test_finish_job_run_retry_no_schedule(connector):
 @pytest.mark.asyncio
 async def test_listen_notify(connector):
     # If we don't crash, it's enough
-    event = asyncio.Event()
+    notify_event = asyncio.Event()
     task = asyncio.create_task(
-        connector.listen_notify(event=event, channels=["channel_name"])
+        connector.listen_notify(
+            channels=["channel_name"], notify_event=notify_event, listen_event=None
+        )
     )
-    await event.wait()
+    await notify_event.wait()
     task.cancel()
 
 

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,3 +1,4 @@
+import asyncio
 import pendulum
 import pytest
 
@@ -256,9 +257,14 @@ def test_finish_job_run_retry_no_schedule(connector):
 
 
 @pytest.mark.asyncio
-async def test_wait_for_activity(connector):
+async def test_listen_notify(connector):
     # If we don't crash, it's enough
-    await connector.wait_for_activity()
+    event = asyncio.Event()
+    task = asyncio.create_task(
+        connector.listen_notify(event=event, channels=["channel_name"])
+    )
+    await event.wait()
+    task.cancel()
 
 
 def test_apply_schema_run(connector):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -94,3 +94,61 @@ async def test_add_sync_api_does_not_break_original_coroutine():
     await Test().a_async()
 
     assert result == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_add_sync_api_classmethods_async():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @classmethod
+        async def a_async(cls, value):
+            result.extend([cls, value])
+
+    await Test.a_async("async")
+
+    assert result == [Test, "async"]
+
+
+def test_add_sync_api_classmethods_sync():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @classmethod
+        async def a_async(cls, value):
+            result.extend([cls, value])
+
+    Test.a("sync")
+
+    assert result == [Test, "sync"]
+
+
+@pytest.mark.asyncio
+async def test_add_sync_api_staticmethods_async():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @staticmethod
+        async def a_async(value):
+            result.append(value)
+
+    await Test.a_async("async")
+
+    assert result == ["async"]
+
+
+def test_add_sync_api_staticmethods_sync():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @staticmethod
+        async def a_async(value):
+            result.append(value)
+
+    Test.a("sync")
+
+    assert result == ["sync"]

--- a/tests/unit/test_worker_sync.py
+++ b/tests/unit/test_worker_sync.py
@@ -19,7 +19,7 @@ def test_worker_load_task_known_missing(app):
 
     task_worker.known_missing_tasks.add("foobarbaz")
     with pytest.raises(exceptions.TaskNotFound):
-        task_worker.load_task("foobarbaz")
+        task_worker.load_task("foobarbaz", {})
 
 
 def test_worker_load_task_known_task(app):
@@ -29,14 +29,16 @@ def test_worker_load_task_known_task(app):
     def task_func():
         pass
 
-    assert task_worker.load_task("tests.unit.test_worker_sync.task_func") == task_func
+    assert (
+        task_worker.load_task("tests.unit.test_worker_sync.task_func", {}) == task_func
+    )
 
 
 def test_worker_load_task_new_missing(app):
     task_worker = worker.Worker(app=app, queues=["yay"])
 
     with pytest.raises(exceptions.TaskNotFound):
-        task_worker.load_task("foobarbaz")
+        task_worker.load_task("foobarbaz", {})
 
     assert task_worker.known_missing_tasks == {"foobarbaz"}
 
@@ -55,7 +57,8 @@ def test_worker_load_task_unknown_task(app, caplog):
     unknown_task = task_func
 
     assert (
-        task_worker.load_task("tests.unit.test_worker_sync.unknown_task") == task_func
+        task_worker.load_task("tests.unit.test_worker_sync.unknown_task", {})
+        == task_func
     )
 
     assert [record for record in caplog.records if record.action == "load_dynamic_task"]


### PR DESCRIPTION
Cf. #148

I've tried to redo and complete my previous approach without touching the "run multiple jobs at the same time" part.
I think the next step will be the separation between sync connector and async connector.

### Successful PR Checklist:
- [x] Tests
- [ ] *Documentation*: Need to write more of it
- [ ] Had a good time contributing? Let's say I'll be glad when this will be behind us.
