### PR TITLE
Add a "Set database schema" how-to

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -62,3 +62,10 @@ Schema
     database. Applying the schema means installing all those objects in the database.
     A evolution in the schema (modifying the table structure, or the procedures) is
     called a migration.
+
+    This term is not to be confused with that of PostgreSQL. In PostgreSQL a database
+    contains one or more *schemas*, which in turn contains tables. Schemas in PostgreSQL
+    are namespaces for objects of the database. See the `PostgreSQL Schema
+    documentation`_ for more detail.
+
+.. _PostgreSQL Schema documentation: https://www.postgresql.org/docs/current/ddl-schemas.html

--- a/docs/howto/set_database_schema.rst
+++ b/docs/howto/set_database_schema.rst
@@ -1,0 +1,26 @@
+Set the database schema
+-----------------------
+
+Any PostgreSQL database contains one or more *schemas*. Schemas are PostgreSQL way of
+implementing namespaces for database objects. See the `PostgreSQL Schema documentation`_
+for more detail on schemas. (See the :ref:`glossary <glossary_schema>` for a note on the
+overloading of the term *schema*.)
+
+By default Procrastinate uses the ``public`` schema, which is PostgreSQL's default
+schema, i.e. the schema that every new database contains.
+
+To have Procrastinate use another schema than ``public``, change the *schema search
+path* when creating the :py:class:`procrastinate.PostgresConnector`::
+
+    app = procrastinate.App(
+        connector=procrastinate.PostgresConnector(
+            host="localhost",
+            options="-c search_path=myschema"
+        )
+    )
+
+With this the ``procrastinate schema --apply`` command will create the Procrastinate
+database objects (tables, functions, etc.) into the ``myschema`` schema. And all the
+SQL queries issued by Procrastinate will apply to the database objects of that schema.
+
+.. _PostgreSQL Schema documentation: https://www.postgresql.org/docs/current/ddl-schemas.html

--- a/docs/howto_index.rst
+++ b/docs/howto_index.rst
@@ -25,3 +25,4 @@ How-to...
     howto/monitoring
     howto/remove_old_jobs
     howto/custom_json_encoder_decoder
+    howto/set_database_schema


### PR DESCRIPTION
This adds an how-to section describing how to make Procrastinate use a specific database schema rather the `public` default schema.

### Successful PR Checklist:
- [ ] Tests **Not relevant**
- [x] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (if not, feel free to give some feedback)
