### PR TITLE
Use a pool instead of a single connection, and reorganize the worker around that

### DIFF
--- a/docs/howto/testing.rst
+++ b/docs/howto/testing.rst
@@ -9,9 +9,8 @@ To use it, you can do::
 
     app = procrastinate.App(connector=procrastinate.testing.InMemoryConnector())
 
-    # Run the jobs your tests created, then stop
-    # the worker:
-    app.run_worker(only_once=True)
+    # Run the jobs your tests created, then stop the worker
+    app.run_worker(wait=False)
 
     # See the jobs created:
     print(app.connector.jobs)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -17,10 +17,14 @@ are accessible through :py:attr:`App.builtin_tasks`:
     app.builtin_tasks["remove_old_jobs"].defer(max_hours=72)
 
 
-Job stores
+Connectors
 ----------
 
+.. This does not indicate that create_with_pool* is an async classmethod because of
+   https://github.com/sphinx-doc/sphinx/issues/7189
+
 .. autoclass:: procrastinate.PostgresConnector
+    :members: create_with_pool, create_with_pool_async, close, close_async
 
 .. autoclass:: procrastinate.testing.InMemoryConnector
     :members: reset

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -1,12 +1,13 @@
+import asyncio
 import logging
 import warnings
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, NoReturn, Optional
 
 import aiopg
 import psycopg2.sql
 from psycopg2.extras import Json, RealDictCursor
 
-from procrastinate import connector, utils
+from procrastinate import connector, sql, utils
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,6 @@ class PostgresConnector(connector.BaseConnector):
     def __init__(
         self,
         pool: aiopg.Pool,
-        socket_timeout: float = connector.SOCKET_TIMEOUT,
         json_dumps: Optional[Callable] = None,
         json_loads: Optional[Callable] = None,
     ):
@@ -33,7 +33,6 @@ class PostgresConnector(connector.BaseConnector):
 
         """
         self._pool = pool
-        self.socket_timeout = socket_timeout
         self.json_dumps = json_dumps
         self.json_loads = json_loads
 
@@ -55,7 +54,6 @@ class PostgresConnector(connector.BaseConnector):
     @classmethod
     async def create_with_pool_async(
         cls,
-        socket_timeout: float = connector.SOCKET_TIMEOUT,
         json_dumps: Optional[Callable] = None,
         json_loads: Optional[Callable] = None,
         **kwargs,
@@ -75,12 +73,6 @@ class PostgresConnector(connector.BaseConnector):
         .. __: https://aiopg.readthedocs.io/en/stable/core.html#aiopg.create_pool
         .. _psycopg2 doc: https://www.psycopg.org/docs/extras.html#json-adaptation
 
-        socket_timeout:
-            This parameter should generally not be changed.
-            It indicates the maximum duration (in seconds) procrastinate workers wait
-            between each database job pull. Job activity will be pushed from the db to
-            the worker, but in case the push mechanism fails somehow, workers will not
-            stay idle longer than the number of seconds indicated by this parameters.
         json_dumps:
             The JSON dumps function to use for serializing job arguments. Defaults to
             the function used by psycopg2. See the `psycopg2 doc`_.
@@ -133,15 +125,22 @@ class PostgresConnector(connector.BaseConnector):
 
         pool = await aiopg.create_pool(**defaults)
 
-        return cls(
-            pool=pool,
-            socket_timeout=socket_timeout,
-            json_dumps=json_dumps,
-            json_loads=json_loads,
-        )
+        return cls(pool=pool, json_dumps=json_dumps, json_loads=json_loads)
+
+    # Pools and single connections do not exactly share their cursor API:
+    # - connection.cursor() is an async context manager (async with)
+    # - pool.cursor() is a coroutine returning a sync context manage (with await)
+    # Because of this, it's easier to have 2 distinct methods for executing from
+    # a pool or from a connection
 
     async def execute_query(self, query: str, **arguments: Any) -> None:
         with await self._pool.cursor() as cursor:
+            await cursor.execute(query, self._wrap_json(arguments))
+
+    async def _execute_query_connection(
+        self, query: str, connection: aiopg.Connection, **arguments: Any,
+    ) -> None:
+        async with connection.cursor() as cursor:
             await cursor.execute(query, self._wrap_json(arguments))
 
     async def execute_query_one(self, query: str, **arguments: Any) -> Dict[str, Any]:
@@ -166,6 +165,29 @@ class PostgresConnector(connector.BaseConnector):
                 for key, value in identifiers.items()
             }
         )
+
+    async def listen_notify(
+        self, event: asyncio.Event, channels: Iterable[str]
+    ) -> NoReturn:
+        # We need to acquire a dedicated connection, and use the listen
+        # query
+        async with self._pool.acquire() as connection:
+            for channel_name in channels:
+                await self._execute_query_connection(
+                    connection=connection,
+                    query=self.make_dynamic_query(
+                        query=sql.queries["listen_queue"], channel_name=channel_name
+                    ),
+                )
+
+            # We'll leave this loop with a CancelError, when we get cancelled
+            while True:
+                event.set()
+                # TODO: because of https://github.com/aio-libs/aiopg/issues/249,
+                # we could get stuck in here forever if the connection closes.
+                # Maybe we should set a timeout and if connection is closed, reopen
+                # a new one.
+                await connection.notifies.get()
 
 
 def PostgresJobStore(*args, **kwargs):

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -105,6 +105,10 @@ class PostgresConnector(connector.BaseConnector):
             Passed to aiopg. Default is :py:class:`psycopg2.extras.RealDictCursor`
             instead of standard cursor. There is no identified use case for changing
             this.
+        maxsize (int):
+            Passed to aiopg. Cannot be lower than 2, otherwise worker won't be
+            functionning normally (one connection for listen/notify, one for executing
+            tasks)
         """
         base_on_connect = kwargs.pop("on_connect", None)
 
@@ -123,6 +127,9 @@ class PostgresConnector(connector.BaseConnector):
             "cursor_factory": RealDictCursor,
         }
         defaults.update(kwargs)
+
+        if "maxsize" in kwargs:
+            kwargs["maxsize"] = max(2, kwargs["maxsize"])
 
         pool = await aiopg.create_pool(**defaults)
 

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -106,7 +106,7 @@ class PostgresConnector(connector.BaseConnector):
 
         async def on_connect(connection):
             if base_on_connect:
-                base_on_connect(connection)
+                await base_on_connect(connection)
             if json_loads:
                 psycopg2.extras.register_default_jsonb(connection.raw, loads=json_loads)
 
@@ -118,10 +118,10 @@ class PostgresConnector(connector.BaseConnector):
             "on_connect": on_connect,
             "cursor_factory": RealDictCursor,
         }
-        defaults.update(kwargs)
-
         if "maxsize" in kwargs:
             kwargs["maxsize"] = max(2, kwargs["maxsize"])
+
+        defaults.update(kwargs)
 
         pool = await aiopg.create_pool(**defaults)
 

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -161,12 +161,11 @@ class PostgresConnector(connector.BaseConnector):
         )
 
 
-class PostgresJobStore(PostgresConnector):
-    def __init__(self, *args, **kwargs):
-        message = (
-            "Use procrastinate.PostgresConnector(...) "
-            "instead of procrastinate.PostgresJobStore(...), with the same arguments"
-        )
-        logger.warn(f"Deprecation Warning: {message}")
-        warnings.warn(DeprecationWarning(message))
-        super().__init__(*args, **kwargs)
+def PostgresJobStore(*args, **kwargs):
+    message = (
+        "Use procrastinate.PostgresConnector(...) "
+        "instead of procrastinate.PostgresJobStore(...), with the same arguments"
+    )
+    logger.warn(f"Deprecation Warning: {message}")
+    warnings.warn(DeprecationWarning(message))
+    return PostgresConnector.create_with_pool(*args, **kwargs)

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import warnings
 from typing import Any, Callable, Dict, List, Optional
@@ -7,29 +6,75 @@ import aiopg
 import psycopg2.sql
 from psycopg2.extras import Json, RealDictCursor
 
-from procrastinate import connector
+from procrastinate import connector, utils
 
 logger = logging.getLogger(__name__)
 
 
+@utils.add_sync_api
 class PostgresConnector(connector.BaseConnector):
     def __init__(
         self,
-        dsn="",
+        pool: aiopg.Pool,
         socket_timeout: float = connector.SOCKET_TIMEOUT,
         json_dumps: Optional[Callable] = None,
         json_loads: Optional[Callable] = None,
-        **kwargs: Any,
     ):
         """
-        All parameters except ``socket_timeout``, ``json_dumps`` and ``json_loads``
-        are passed to :py:func:`aiopg.connect` (see the documentation__)
+        The pool connections are expected to have jsonb adapters.
 
-        .. __: https://aiopg.readthedocs.io/en/stable/core.html#connection
-        .. _psycopg2 doc: https://www.psycopg.org/docs/extras.html#json-adaptation
+        See parameter details in :py:func:`PostgresConnector.create_with_pool`.
 
         Parameters
         ----------
+        pool:
+            An aiopg pool, either externally configured or passed by
+            :py:func:`PostgresConnector.create_with_pool`.
+
+        """
+        self._pool = pool
+        self.socket_timeout = socket_timeout
+        self.json_dumps = json_dumps
+        self.json_loads = json_loads
+
+    async def close_async(self) -> None:
+        """
+        Closes the pool and awaits all connections to be released.
+        """
+        self._pool.close()
+        await self._pool.wait_closed()
+
+    def _wrap_json(self, arguments: Dict[str, Any]):
+        return {
+            key: Json(value, dumps=self.json_dumps)
+            if isinstance(value, dict)
+            else value
+            for key, value in arguments.items()
+        }
+
+    @classmethod
+    async def create_with_pool_async(
+        cls,
+        socket_timeout: float = connector.SOCKET_TIMEOUT,
+        json_dumps: Optional[Callable] = None,
+        json_loads: Optional[Callable] = None,
+        **kwargs,
+    ) -> aiopg.Pool:
+        """
+        Creates a connector, and its connection pool, using the provided parameters.
+        All additional parameters will be used to create a
+        :py:func:`aiopg.Pool` (see the documentation__), sometimes with a different
+        default value.
+
+        When using this method, you explicitely take the responsibility for opening the
+        pool. It's your responsibility to call
+        :py:func:`procrastinate.PostgresConnector.close` or
+        :py:func:`procrastinate.PostgresConnector.close_async` to close connections
+        when your process ends.
+
+        .. __: https://aiopg.readthedocs.io/en/stable/core.html#aiopg.create_pool
+        .. _psycopg2 doc: https://www.psycopg.org/docs/extras.html#json-adaptation
+
         socket_timeout:
             This parameter should generally not be changed.
             It indicates the maximum duration (in seconds) procrastinate workers wait
@@ -41,76 +86,71 @@ class PostgresConnector(connector.BaseConnector):
             the function used by psycopg2. See the `psycopg2 doc`_.
         json_loads:
             The JSON loads function to use for deserializing job arguments. Defaults
-            to the function used by psycopg2. See the `psycopg2 doc`_.
-
+            to the function used by psycopg2. See the `psycopg2 doc`_. Unused if pool
+            is passed.
+        dsn (Optional[str]):
+            Passed to aiopg. Default is "" instead of None, which means if no argument
+            is passed, it will connect to localhost:5432 instead of a Unix-domain
+            local socket file.
+        enable_json (bool):
+            Passed to aiopg. Default is False instead of True to avoid messing with
+            the global state.
+        enable_hstore (bool):
+            Passed to aiopg. Default is False instead of True to avoid messing with
+            the global state.
+        enable_uuid (bool):
+            Passed to aiopg. Default is False instead of True to avoid messing with
+            the global state.
+        cursor_factory (psycopg2.extensions.cursor):
+            Passed to aiopg. Default is :py:class:`psycopg2.extras.RealDictCursor`
+            instead of standard cursor. There is no identified use case for changing
+            this.
         """
-        kwargs["dsn"] = dsn
-        self._connection_parameters = kwargs
-        self._connection: Optional[aiopg.Connection] = None
-        self._lock = asyncio.Lock()
-        self.socket_timeout = socket_timeout
-        self.json_dumps = json_dumps
-        self.json_loads = json_loads
+        base_on_connect = kwargs.pop("on_connect", None)
 
-    async def close_connection(self) -> None:
-        if not self._connection or self._connection.closed:
-            return
-        await self._connection.close()
+        async def on_connect(connection):
+            if base_on_connect:
+                base_on_connect(connection)
+            if json_loads:
+                psycopg2.extras.register_default_jsonb(connection.raw, loads=json_loads)
 
-    def _wrap_json(self, arguments: Dict[str, Any]):
-        return {
-            key: Json(value, dumps=self.json_dumps)
-            if isinstance(value, dict)
-            else value
-            for key, value in arguments.items()
+        defaults = {
+            "dsn": "",
+            "enable_json": False,
+            "enable_hstore": False,
+            "enable_uuid": False,
+            "on_connect": on_connect,
+            "cursor_factory": RealDictCursor,
         }
+        defaults.update(kwargs)
 
-    async def _get_connection(self) -> aiopg.Connection:
-        # fast path
-        if self._connection and not self._connection.closed:
-            return self._connection
-        async with self._lock:
-            if self._connection and not self._connection.closed:
-                return self._connection
-            # tell aiopg not to register adapters for hstore & json by default, as
-            # those are registered at the module level and could overwrite previously
-            # defined adapters
-            kwargs = self._connection_parameters
-            kwargs.setdefault("enable_json", False)
-            kwargs.setdefault("enable_hstore", False)
-            kwargs.setdefault("enable_uuid", False)
-            conn = await aiopg.connect(**kwargs)
-            if self.json_loads:
-                psycopg2.extras.register_default_jsonb(conn.raw, loads=self.json_loads)
-            self._connection = conn
-            return conn
+        pool = await aiopg.create_pool(**defaults)
+
+        return cls(
+            pool=pool,
+            socket_timeout=socket_timeout,
+            json_dumps=json_dumps,
+            json_loads=json_loads,
+        )
 
     async def execute_query(self, query: str, **arguments: Any) -> None:
-        connection = await self._get_connection()
-        async with self._lock:
-            # aiopg can work with psycopg2's cursor class
-            async with connection.cursor(cursor_factory=RealDictCursor) as cursor:
-                await cursor.execute(query, self._wrap_json(arguments))
+        with await self._pool.cursor() as cursor:
+            await cursor.execute(query, self._wrap_json(arguments))
 
     async def execute_query_one(self, query: str, **arguments: Any) -> Dict[str, Any]:
-        connection = await self._get_connection()
-        async with self._lock:
-            # aiopg can work with psycopg2's cursor class
-            async with connection.cursor(cursor_factory=RealDictCursor) as cursor:
-                await cursor.execute(query, self._wrap_json(arguments))
+        with await self._pool.cursor() as cursor:
+            await cursor.execute(query, self._wrap_json(arguments))
 
-                return await cursor.fetchone()
+            return await cursor.fetchone()
 
     async def execute_query_all(
         self, query: str, **arguments: Any
     ) -> List[Dict[str, Any]]:
-        connection = await self._get_connection()
-        async with self._lock:
-            # aiopg can work with psycopg2's cursor class
-            async with connection.cursor(cursor_factory=RealDictCursor) as cursor:
-                await cursor.execute(query, self._wrap_json(arguments))
 
-                return await cursor.fetchall()
+        with await self._pool.cursor() as cursor:
+            await cursor.execute(query, self._wrap_json(arguments))
+
+            return await cursor.fetchall()
 
     def make_dynamic_query(self, query: str, **identifiers: str) -> str:
         return psycopg2.sql.SQL(query).format(
@@ -118,23 +158,6 @@ class PostgresConnector(connector.BaseConnector):
                 key: psycopg2.sql.Identifier(value)
                 for key, value in identifiers.items()
             }
-        )
-
-    async def wait_for_activity(self):
-        connection = await self._get_connection()
-        try:
-            await asyncio.wait_for(
-                connection.notifies.get(), timeout=self.socket_timeout
-            )
-        except asyncio.TimeoutError:
-            pass
-
-    # This can be called from a signal handler, better not do async stuff
-    def interrupt_wait(self):
-        if not self._connection or self._connection.closed:
-            return
-        asyncio.get_event_loop().call_soon_threadsafe(
-            self._connection.notifies.put_nowait, "s"
         )
 
 

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -65,7 +65,7 @@ class App:
             workers wait between each database job pull. Job activity will be pushed
             from the db to the worker, but in case the push mechanism fails somehow,
             workers will not stay idle longer than the number of seconds indicated by
-            this parameters.
+            this parameter.
             Raising this parameter can lower the rate of workers making queries to the
             database for requesting jobs.
         job_store:

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -221,8 +221,7 @@ class App:
     ) -> None:
         """
         Run a worker. This worker will run in the foreground and the function will not
-        return until the worker stops (most probably when it receives a stop signal)
-        (except if `only_once` is True).
+        return until the worker stops (most probably when it receives a stop signal).
 
         Parameters
         ----------

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Set
 
 from procrastinate import builtin_tasks
 from procrastinate import connector as connector_module
-from procrastinate import exceptions, healthchecks, jobs
+from procrastinate import healthchecks, jobs
 from procrastinate import retry as retry_module
 from procrastinate import schema, store, utils
 
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
     from procrastinate import tasks, worker
 
 logger = logging.getLogger(__name__)
+
+WORKER_TIMEOUT = 5.0  # seconds
 
 
 @utils.add_sync_api
@@ -35,6 +37,7 @@ class App:
         *,
         connector: Optional[connector_module.BaseConnector] = None,
         import_paths: Optional[Iterable[str]] = None,
+        worker_timeout: float = WORKER_TIMEOUT,
         # Just for backwards compatibility
         job_store: Optional[connector_module.BaseConnector] = None,
     ):
@@ -57,6 +60,14 @@ class App:
             A :py:func:`App.task` that has a custom "name" parameter, that is not
             imported and whose module path is not in this list will
             fail to run.
+        worker_timeout:
+            This parameter indicates the maximum duration (in seconds) procrastinate
+            workers wait between each database job pull. Job activity will be pushed
+            from the db to the worker, but in case the push mechanism fails somehow,
+            workers will not stay idle longer than the number of seconds indicated by
+            this parameters.
+            Raising this parameter can lower the rate of workers making queries to the
+            database for requesting jobs.
         job_store:
             **Deprecated**: Old name of ``connector``.
         """
@@ -77,6 +88,7 @@ class App:
         self.builtin_tasks: Dict[str, "tasks.Task"] = {}
         self.queues: Set[str] = set()
         self.import_paths = import_paths or []
+        self.worker_timeout = worker_timeout
 
         self.job_store = store.JobStore(connector=self.connector)
 
@@ -181,11 +193,13 @@ class App:
         return tasks.configure_task(name=name, job_store=self.job_store, **kwargs)
 
     def _worker(
-        self, queues: Optional[Iterable[str]] = None, name: Optional[str] = None
+        self, queues: Optional[Iterable[str]], name: Optional[str], wait: bool
     ) -> "worker.Worker":
         from procrastinate import worker
 
-        return worker.Worker(app=self, queues=queues, name=name)
+        return worker.Worker(
+            app=self, queues=queues, name=name, timeout=self.worker_timeout, wait=wait
+        )
 
     @functools.lru_cache(maxsize=1)
     def perform_import_paths(self):
@@ -203,32 +217,23 @@ class App:
         self,
         queues: Optional[Iterable[str]] = None,
         name: Optional[str] = None,
-        only_once: bool = False,
+        wait: bool = True,
     ) -> None:
         """
-        Run a worker. This worker will run in the foreground
-        and the function will not return until the worker stops
-        (most probably when it receives a stop signal) (except if
-        `only_once` is True).
+        Run a worker. This worker will run in the foreground and the function will not
+        return until the worker stops (most probably when it receives a stop signal)
+        (except if `only_once` is True).
 
         Parameters
         ----------
         queues:
-            List of queues to listen to, or None to listen to
-            every queue.
-        only_once:
-            If True, the worker will run but just for the currently
-            defined tasks. This function will return when the
-            listened queues are empty.
+            List of queues to listen to, or None to listen to every queue.
+        wait:
+            If False, worker will terminate as soon as it has caught up with the queues.
         """
-        worker = self._worker(queues=queues, name=name)
-        if only_once:
-            try:
-                await worker.process_jobs_once()
-            except (exceptions.NoMoreJobs, exceptions.StopRequested):
-                pass
-        else:
-            await worker.run()
+        self.perform_import_paths()
+        worker = self._worker(queues=queues, name=name, wait=wait)
+        await worker.run()
 
     @property
     def schema_manager(self) -> schema.SchemaManager:

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -237,6 +237,3 @@ class App:
     @property
     def health_check_runner(self) -> healthchecks.HealthCheckRunner:
         return healthchecks.HealthCheckRunner(connector=self.connector)
-
-    async def close_connection_async(self):
-        await self.connector.close_connection()

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import json
 import logging
@@ -105,7 +106,9 @@ def cli(ctx: click.Context, app: str, **kwargs) -> None:
 @click.pass_obj
 def close_connection(procrastinate_app: procrastinate.App, *args, **kwargs):
     # There's an internal click param named app, we can't name our variable "app" too.
-    procrastinate_app.close_connection()  # type: ignore
+    procrastinate_app.connector.close()
+
+    asyncio.get_event_loop().close()
 
 
 @cli.command()

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -6,7 +6,10 @@ class BaseConnector:
     json_dumps: Optional[Callable] = None
     json_loads: Optional[Callable] = None
 
-    async def close(self) -> None:
+    async def close_async(self) -> None:
+        pass
+
+    def close(self) -> None:
         pass
 
     async def execute_query(self, query: str, **arguments: Any) -> None:

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -7,7 +7,7 @@ class BaseConnector:
     json_dumps: Optional[Callable] = None
     json_loads: Optional[Callable] = None
 
-    async def close_connection(self) -> None:
+    async def close(self) -> None:
         pass
 
     async def execute_query(self, query: str, **arguments: Any) -> None:
@@ -22,10 +22,4 @@ class BaseConnector:
         raise NotImplementedError
 
     def make_dynamic_query(self, query: str, **identifiers: str) -> str:
-        raise NotImplementedError
-
-    async def wait_for_activity(self) -> None:
-        raise NotImplementedError
-
-    def interrupt_wait(self):
         raise NotImplementedError

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -1,6 +1,5 @@
-from typing import Any, Callable, Dict, List, Optional
-
-SOCKET_TIMEOUT = 5.0  # seconds
+import asyncio
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 
 class BaseConnector:
@@ -22,4 +21,9 @@ class BaseConnector:
         raise NotImplementedError
 
     def make_dynamic_query(self, query: str, **identifiers: str) -> str:
+        raise NotImplementedError
+
+    async def listen_notify(
+        self, event: asyncio.Event, channels: Iterable[str]
+    ) -> None:
         raise NotImplementedError

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -20,11 +20,3 @@ class LoadFromPathError(ImportError, ProcrastinateException):
 class JobRetry(ProcrastinateException):
     def __init__(self, scheduled_at: datetime.datetime):
         self.scheduled_at = scheduled_at
-
-
-class StopRequested(ProcrastinateException):
-    pass
-
-
-class NoMoreJobs(ProcrastinateException):
-    pass

--- a/procrastinate/signals.py
+++ b/procrastinate/signals.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import signal
+import sys
 import threading
 from contextlib import contextmanager
 from typing import Any, Callable, Optional
@@ -37,7 +38,10 @@ def on_stop(callback: Callable[[], None]):
     uninstalled = False
     loop: Optional[asyncio.AbstractEventLoop]
     try:
-        loop = asyncio.get_running_loop()
+        if sys.version_info < (3, 7):
+            loop = asyncio.get_event_loop()
+        else:
+            loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = None
 

--- a/procrastinate/signals.py
+++ b/procrastinate/signals.py
@@ -37,13 +37,16 @@ def on_stop(callback: Callable[[], None]):
 
     uninstalled = False
     loop: Optional[asyncio.AbstractEventLoop]
-    try:
-        if sys.version_info < (3, 7):
+    if sys.version_info < (3, 7):
+        if asyncio.Task.current_task():
             loop = asyncio.get_event_loop()
         else:
+            loop = None
+    else:
+        try:
             loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
+        except RuntimeError:
+            loop = None
 
     def uninstall_and_callback(*args) -> None:
         nonlocal uninstalled

--- a/procrastinate/signals.py
+++ b/procrastinate/signals.py
@@ -1,17 +1,29 @@
+import asyncio
 import logging
 import signal
 import threading
+import types
 from contextlib import contextmanager
-from types import FrameType
 from typing import Callable
 
 logger = logging.getLogger(__name__)
 
-Signals = signal.Signals
+# A few things about signals and asyncio:
+# - https://docs.python.org/3/library/asyncio-eventloop.html#unix-signals
+# - If you don't use loop.add_signal_handler, your handler has no effect on the queue
+# - asyncio signal primitives don't give you a way to get the current handler for a
+#   signal
+# - If a signal has an asyncio handler, its "standard handler (installed through
+#   signal.signal) is ignored (you can't get it, you can't set one, it doesn't get
+#   called on the signal).
+# - asyncio handlers receive no parameter
+# This all mean we have to save the previous signals before installing ours, and for
+# uninstalling, we need to remove the async handler and only then re-add the normal
+# one. And hope that there was no previously set async handler.
 
 
 @contextmanager
-def on_stop(callback: Callable[[signal.Signals, FrameType], None]):
+def on_stop(callback: Callable[[], None]):
     if threading.current_thread() is not threading.main_thread():
         logger.debug(
             "Skipping signal handling, because this is not the main thread",
@@ -22,13 +34,21 @@ def on_stop(callback: Callable[[signal.Signals, FrameType], None]):
 
     sigint_handler = signal.getsignal(signal.SIGINT)
     sigterm_handler = signal.getsignal(signal.SIGTERM)
+    loop = asyncio.get_running_loop()
+
+    def uninstall_and_callback() -> None:
+        loop.remove_signal_handler(signal.SIGINT)
+        loop.remove_signal_handler(signal.SIGTERM)
+        signal.signal(signal.SIGINT, sigint_handler)
+        signal.signal(signal.SIGTERM, sigterm_handler)
+        callback()
 
     try:
         logger.debug(
             "Installing signal handler", extra={"action": "install_signal_handlers"}
         )
-        signal.signal(signal.SIGINT, callback)
-        signal.signal(signal.SIGTERM, callback)
+        loop.add_signal_handler(signal.SIGINT, uninstall_and_callback)
+        loop.add_signal_handler(signal.SIGTERM, uninstall_and_callback)
 
         yield
     finally:
@@ -36,5 +56,7 @@ def on_stop(callback: Callable[[signal.Signals, FrameType], None]):
             "Resetting previous signal handler",
             extra={"action": "uninstall_signal_handlers"},
         )
+        loop.remove_signal_handler(signal.SIGINT)
+        loop.remove_signal_handler(signal.SIGTERM)
         signal.signal(signal.SIGINT, sigint_handler)
         signal.signal(signal.SIGTERM, sigterm_handler)

--- a/procrastinate/store.py
+++ b/procrastinate/store.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 from typing import Iterable, Optional
 
@@ -91,11 +92,9 @@ class JobStore:
             scheduled_at=scheduled_at,
         )
 
-    async def listen_for_jobs(self, queues: Optional[Iterable[str]] = None) -> None:
-        for channel_name in get_channel_for_queues(queues=queues):
-
-            await self.connector.execute_query(
-                query=self.connector.make_dynamic_query(
-                    query=sql.queries["listen_queue"], channel_name=channel_name
-                )
-            )
+    async def listen_for_jobs(
+        self, *, event: asyncio.Event, queues: Optional[Iterable[str]] = None,
+    ) -> None:
+        await self.connector.listen_notify(
+            event=event, channels=get_channel_for_queues(queues=queues)
+        )

--- a/procrastinate/store.py
+++ b/procrastinate/store.py
@@ -16,10 +16,6 @@ class JobStore:
     def __init__(self, connector: connector.BaseConnector):
         self.connector = connector
 
-    # stop, being called in a signal handler, may NOT be an awaitable
-    def stop(self):
-        self.connector.interrupt_wait()
-
     async def defer_job(self, job: jobs.Job) -> int:
         result = await self.connector.execute_query_one(
             query=sql.queries["defer_job"],

--- a/procrastinate/store.py
+++ b/procrastinate/store.py
@@ -15,9 +15,6 @@ class JobStore:
     def __init__(self, connector: connector.BaseConnector):
         self.connector = connector
 
-    async def wait_for_jobs(self):
-        return await self.connector.wait_for_activity()
-
     # stop, being called in a signal handler, may NOT be an awaitable
     def stop(self):
         self.connector.interrupt_wait()

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -48,13 +48,8 @@ class InMemoryConnector(connector.BaseConnector):
         on this class. Suffix is "run" if no result is expected,
         "one" if a single result, and "all" if multiple results.
         """
-        if query.startswith("LISTEN"):
-            query_name = "listen_for_jobs"
-            prefix_length = len("LISTEN ")
-            self.queries.append((query_name, query[prefix_length:-1]))
-        else:
-            query_name = self.reverse_queries[query]
-            self.queries.append((query_name, arguments))
+        query_name = self.reverse_queries[query]
+        self.queries.append((query_name, arguments))
         return getattr(self, f"{query_name}_{suffix}")(**arguments)
 
     def make_dynamic_query(self, query, **identifiers: str) -> str:

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -102,5 +102,9 @@ def sync_await(awaitable: Awaitable[T]) -> T:
     """
     Given an awaitable, awaits it synchronously. Returns the result after it's done.
     """
+
     loop = asyncio.get_event_loop()
+    if loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
     return loop.run_until_complete(awaitable)

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -93,6 +93,8 @@ def wrap_one(cls: Type, attribute_name: str):
         final_wrapper = classmethod(wrapper)
     elif isinstance(attribute, staticmethod):
         final_wrapper = staticmethod(wrapper)
+    else:
+        raise ValueError(f"Invalid object of type {type(attribute)}")
 
     # Save this new method on the class
     name = wrapper.__name__ = attribute_name[: -len(suffix)]

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -1,8 +1,8 @@
 import asyncio
-import functools
 import importlib
 import logging
-from typing import Awaitable, Iterable, Type, TypeVar
+import types
+from typing import Any, Awaitable, Iterable, Type, TypeVar
 
 from procrastinate import exceptions
 
@@ -67,21 +67,35 @@ def wrap_one(cls: Type, attribute_name: str):
     if attribute_name.startswith("_") or not attribute_name.endswith(suffix):
         return
 
-    attribute = getattr(cls, attribute_name)
+    # Methods are descriptors so using getattr here will not give us the real method
+    cls_vars = vars(cls)
+    attribute = cls_vars[attribute_name]
+
+    # If method is a classmethod or staticmethod, its real function, that may be
+    # async, is stored in __func__.
+    wrapped = getattr(attribute, "__func__", attribute)
 
     # Keep only async def methods
-    if not asyncio.iscoroutinefunction(attribute):
+    if not asyncio.iscoroutinefunction(wrapped):
         return
 
     # Create a wrapper that will call the method in a run_until_complete
-    @functools.wraps(attribute)
-    def wrapper(self, *args, **kwargs):
-        awaitable = attribute(self, *args, **kwargs)
+    # @functools.wraps(attribute)
+    def wrapper(*args, **kwargs):
+        awaitable = wrapped(*args, **kwargs)
         return sync_await(awaitable=awaitable)
+
+    final_wrapper: Any
+    if isinstance(attribute, types.FunctionType):  # classic method
+        final_wrapper = wrapper
+    elif isinstance(attribute, classmethod):
+        final_wrapper = classmethod(wrapper)
+    elif isinstance(attribute, staticmethod):
+        final_wrapper = staticmethod(wrapper)
 
     # Save this new method on the class
     name = wrapper.__name__ = attribute_name[: -len(suffix)]
-    setattr(cls, name, wrapper)
+    setattr(cls, name, final_wrapper)
 
 
 def sync_await(awaitable: Awaitable[T]) -> T:

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import importlib
 import logging
 import types
@@ -80,7 +81,7 @@ def wrap_one(cls: Type, attribute_name: str):
         return
 
     # Create a wrapper that will call the method in a run_until_complete
-    # @functools.wraps(attribute)
+    @functools.wraps(wrapped)
     def wrapper(*args, **kwargs):
         awaitable = wrapped(*args, **kwargs)
         return sync_await(awaitable=awaitable)

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -49,7 +49,7 @@ class Worker:
 
     @contextlib.contextmanager
     def listener(self):
-        notifier = asyncio.create_task(
+        notifier = asyncio.ensure_future(
             self.job_store.listen_for_jobs(event=self.notify_event, queues=self.queues)
         )
         try:

--- a/procrastinate_demo/__main__.py
+++ b/procrastinate_demo/__main__.py
@@ -16,7 +16,7 @@ def main():
     tasks.sleep.configure(lock="a").defer(i=4)
     tasks.random_fail.defer()
 
-    app.close_connection()
+    app.connector.close()
 
 
 if __name__ == "__main__":

--- a/procrastinate_demo/app.py
+++ b/procrastinate_demo/app.py
@@ -1,6 +1,6 @@
 import procrastinate
 
 app = procrastinate.App(
-    connector=procrastinate.PostgresConnector(),
+    connector=procrastinate.PostgresConnector.create_with_pool(),  # type: ignore
     import_paths=["procrastinate_demo.tasks"],
 )

--- a/tests/acceptance/app.py
+++ b/tests/acceptance/app.py
@@ -25,7 +25,7 @@ json_dumps = functools.partial(json.dumps, default=encode)
 json_loads = functools.partial(json.loads, object_hook=decode)
 
 app = procrastinate.App(
-    connector=procrastinate.PostgresConnector(
+    connector=procrastinate.PostgresConnector.create_with_pool(  # type: ignore
         json_dumps=json_dumps, json_loads=json_loads
     )
 )

--- a/tests/acceptance/param.py
+++ b/tests/acceptance/param.py
@@ -1,7 +1,7 @@
 class Param:
     p: int
 
-    def __init__(self, p: str):
+    def __init__(self, p: int):
         self.p = p
 
     def __add__(self, other: "Param"):

--- a/tests/acceptance/test_async.py
+++ b/tests/acceptance/test_async.py
@@ -28,7 +28,7 @@ async def test_defer(pg_app):
     await pg_app.configure_task(name="sum_task").defer_async(a=5, b=6)
     await product_task.defer_async(a=3, b=4)
 
-    await pg_app.run_worker_async(queues=["default"], only_once=True)
+    await pg_app.run_worker_async(queues=["default"], wait=False)
 
     assert sum_results == [3, 7, 11]
     assert product_results == [12]

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -5,9 +5,6 @@ import time
 
 import pytest
 
-from .app import json_dumps
-from .param import Param
-
 
 @pytest.fixture
 def process_env(connection_params):
@@ -24,6 +21,8 @@ def process_env(connection_params):
 
 @pytest.fixture
 def defer(process_env):
+    from .app import json_dumps
+
     def func(task_name, lock=None, **kwargs):
         lock_args = ["--lock", lock] if lock else []
         full_task_name = f"tests.acceptance.app.{task_name}"
@@ -61,6 +60,7 @@ def running_worker(process_env):
 
 
 def test_nominal(defer, worker):
+    from .param import Param
 
     defer("sum_task", a=5, b=7)
     defer("sum_task_param", p1=Param(3), p2=Param(4))

--- a/tests/integration/test_aiopg_connector.py
+++ b/tests/integration/test_aiopg_connector.py
@@ -26,15 +26,10 @@ async def pg_connector_factory(connection_params):
         await connector.close_async()
 
 
-async def test_create_with_pool(connection_params):
-    connector = await aiopg_connector.PostgresConnector.create_with_pool_async(
-        **connection_params
-    )
-    try:
-        async with connector._pool.acquire() as connection:
-            assert connection.dsn == "dbname=" + connection_params["dbname"]
-    finally:
-        await connector.close_async()
+async def test_create_with_pool(pg_connector_factory, connection_params):
+    connector = await pg_connector_factory(**connection_params)
+    async with connector._pool.acquire() as connection:
+        assert connection.dsn == "dbname=" + connection_params["dbname"]
 
 
 async def test_create_with_pool_on_connect(pg_connector_factory):
@@ -123,10 +118,10 @@ async def test_close_async(pg_connector):
 
 
 async def test_get_connection_no_psycopg2_adapter_registration(
-    connection_params, mocker
+    pg_connector_factory, mocker
 ):
     register_adapter = mocker.patch("psycopg2.extensions.register_adapter")
-    await aiopg_connector.PostgresConnector.create_with_pool_async(**connection_params)
+    await pg_connector_factory()
     assert not register_adapter.called
 
 

--- a/tests/integration/test_aiopg_connector.py
+++ b/tests/integration/test_aiopg_connector.py
@@ -130,7 +130,7 @@ async def test_listen_notify(pg_connector):
     channel = "somechannel"
     event = asyncio.Event()
 
-    task = asyncio.create_task(
+    task = asyncio.ensure_future(
         pg_connector.listen_notify(channels=[channel], event=event)
     )
     try:
@@ -166,7 +166,7 @@ async def test_loop_notify_timeout(pg_connector):
     # connection closes, we eventually finish the coroutine.
     event = asyncio.Event()
     async with pg_connector._pool.acquire() as connection:
-        task = asyncio.create_task(
+        task = asyncio.ensure_future(
             pg_connector._loop_notify(event=event, connection=connection, timeout=0.01)
         )
         await asyncio.sleep(0.1)

--- a/tests/integration/test_aiopg_connector.py
+++ b/tests/integration/test_aiopg_connector.py
@@ -37,6 +37,24 @@ async def test_create_with_pool(connection_params):
         await connector.close_async()
 
 
+async def test_create_with_pool_on_connect(pg_connector_factory):
+    called = []
+
+    async def on_connect(connection):
+        called.append(connection)
+
+    connector = await pg_connector_factory(on_connect=on_connect)
+    await connector.execute_query("SELECT 1")
+
+    assert len(called) > 0
+    assert isinstance(called[0], aiopg.Connection)
+
+
+async def test_create_with_pool_maxsize(pg_connector_factory):
+    connector = await pg_connector_factory(maxsize=1)
+    assert connector._pool.maxsize == 2
+
+
 @pytest.mark.parametrize(
     "method_name, result",
     [

--- a/tests/integration/test_aiopg_connector.py
+++ b/tests/integration/test_aiopg_connector.py
@@ -13,42 +13,25 @@ pytestmark = pytest.mark.asyncio
 async def pg_connector_factory(connection_params):
     connectors = []
 
-    def _(**kwargs):
+    async def _(**kwargs):
         connection_params.update(kwargs)
-        connector = aiopg_connector.PostgresConnector(**connection_params)
+        connector = await aiopg_connector.PostgresConnector.create_with_pool_async(
+            **connection_params
+        )
         connectors.append(connector)
         return connector
 
     yield _
     for connector in connectors:
-        await connector.close_connection()
+        await connector.close_async()
 
 
-async def test_get_connection(pg_connector, connection_params):
-    async with await pg_connector._get_connection() as connection:
-
+async def test_create_with_pool(connection_params):
+    connector = await aiopg_connector.PostgresConnector.create_with_pool_async(
+        **connection_params
+    )
+    async with connector._pool.acquire() as connection:
         assert connection.dsn == "dbname=" + connection_params["dbname"]
-
-
-async def test_get_connection_json_loads(pg_connector_factory, mocker):
-    json_loads = mocker.MagicMock()
-    register_default_jsonb = mocker.patch("psycopg2.extras.register_default_jsonb")
-    connector = pg_connector_factory(json_loads=json_loads)
-    async with await connector._get_connection() as connection:
-        register_default_jsonb.assert_called_with(connection.raw, loads=json_loads)
-
-
-async def test_get_connection_simultaneous(pg_connector):
-    # two coroutines doing _get_connection simultaneously
-    #
-    # the test fails because two separate connections are created if no lock is
-    # used in _get_connection
-
-    async def get_connection():
-        return await pg_connector._get_connection()
-
-    connections = await asyncio.gather(get_connection(), get_connection())
-    assert connections[0] is connections[1]
 
 
 @pytest.mark.parametrize(
@@ -72,7 +55,7 @@ async def test_execute_query_one_json_loads(
     query = "SELECT %(arg)s::jsonb as json"
     arg = {"a": "a", "b": NotJSONSerializableByDefault()}
     json_dumps = functools.partial(json.dumps, default=encode)
-    connector = pg_connector_factory(json_dumps=json_dumps)
+    connector = await pg_connector_factory(json_dumps=json_dumps)
     method = getattr(connector, method_name)
 
     result = await method(query, arg=arg)
@@ -101,8 +84,7 @@ async def test_execute_query(pg_connector):
 async def test_execute_query_simultaneous(pg_connector):
     # two coroutines doing execute_query simulteneously
     #
-    # the test fails because of a ResourceWarning error if the lock is not hold
-    # while creating the cursor on the connection
+    # the test may fail if the connector fails to properly parallelize connections
 
     async def query():
         await pg_connector.execute_query("SELECT 1")
@@ -113,39 +95,15 @@ async def test_execute_query_simultaneous(pg_connector):
         pytest.fail("ResourceWarning")
 
 
-async def test_close_connection(pg_connector):
-    await pg_connector._get_connection()
-    await pg_connector.close_connection()
-    assert pg_connector._connection.closed == 1
+async def test_close_async(pg_connector):
+    await pg_connector.execute_query("SELECT 1")
+    await pg_connector.close_async()
+    assert pg_connector._pool.closed is True
 
 
-async def test_close_connection_no_connection(pg_connector):
-    await pg_connector.close_connection()
-    # Well we didn't crash. Great.
-
-
-async def test_stop_no_connection(pg_connector):
-    pg_connector.interrupt_wait()
-    # Well we didn't crash. Great.
-
-
-async def test_get_connection_called_twice(pg_connector):
-    conn1 = await pg_connector._get_connection()
-    assert not conn1.closed
-    conn2 = await pg_connector._get_connection()
-    assert conn2 is conn1
-
-
-async def test_get_connection_after_close(pg_connector):
-    conn1 = await pg_connector._get_connection()
-    assert not conn1.closed
-    await pg_connector.close_connection()
-    conn2 = await pg_connector._get_connection()
-    assert not conn2.closed
-    assert conn2 is not conn1
-
-
-async def test_get_connection_no_psycopg2_adapter_registration(pg_connector, mocker):
+async def test_get_connection_no_psycopg2_adapter_registration(
+    connection_params, mocker
+):
     register_adapter = mocker.patch("psycopg2.extensions.register_adapter")
-    await pg_connector._get_connection()
+    await aiopg_connector.PostgresConnector.create_with_pool_async(**connection_params)
     assert not register_adapter.called

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -1,7 +1,6 @@
-import psycopg2
 import pytest
 
-from procrastinate import aiopg_connector, jobs
+from procrastinate import jobs
 from procrastinate.healthchecks import HealthCheckRunner
 
 pytestmark = pytest.mark.asyncio

--- a/tests/integration/test_healthchecks.py
+++ b/tests/integration/test_healthchecks.py
@@ -21,14 +21,3 @@ async def test_get_status_count(checker):
     assert set(status_count.keys()) == set(jobs.Status)
     for known_status in jobs.Status:
         assert status_count[known_status] == 0
-
-
-@pytest.mark.parametrize(
-    "method", ["check_connection_async", "get_status_count_async"],
-)
-async def test_db_down(method):
-    bad_job_store = aiopg_connector.PostgresConnector(dsn="", dbname="a_bad_db_name")
-    checker = HealthCheckRunner(bad_job_store)
-
-    with pytest.raises(psycopg2.Error):
-        await getattr(checker, method)()

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1,7 +1,4 @@
-import asyncio
 import datetime
-import random
-import string
 
 import pendulum
 import pytest

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import random
 import string
@@ -345,30 +346,6 @@ async def test_finish_job_retry(get_all, pg_job_store):
 
     assert job2.id == job1.id
     assert job2.attempts == job1.attempts + 1
-
-
-async def test_listen_for_jobs(pg_job_store, pg_connector):
-    queue = "".join(random.choices(string.ascii_letters, k=10))
-    queue_full_name = f"procrastinate_queue#{queue}"
-
-    await pg_job_store.listen_for_jobs(queues=[queue])
-
-    count = await pg_connector.execute_query_one(
-        """SELECT COUNT(*) FROM pg_listening_channels()
-                          WHERE pg_listening_channels = %(queue)s""",
-        queue=queue_full_name,
-    )
-    assert count["count"] == 1
-
-
-async def test_listen_for_jobs_all_queue(pg_job_store, pg_connector):
-    await pg_job_store.listen_for_jobs()
-
-    count = await pg_connector.execute_query_one(
-        """SELECT COUNT(*) FROM pg_listening_channels()
-           WHERE pg_listening_channels = 'procrastinate_any_queue'"""
-    )
-    assert count["count"] == 1
 
 
 async def test_enum_synced(pg_connector):

--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -13,7 +13,7 @@ async def test_wait_for_activity(pg_connector):
     """
     pg_app = app.App(connector=pg_connector)
     worker = worker_module.Worker(app=pg_app, timeout=2)
-    task = asyncio.create_task(worker.single_worker())
+    task = asyncio.ensure_future(worker.single_worker())
     await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
     worker.stop_requested = True
@@ -32,7 +32,7 @@ async def test_wait_for_activity_timeout(pg_connector):
     """
     pg_app = app.App(connector=pg_connector)
     worker = worker_module.Worker(app=pg_app, timeout=2)
-    task = asyncio.create_task(worker.single_worker())
+    task = asyncio.ensure_future(worker.single_worker())
     try:
         await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
@@ -51,7 +51,7 @@ async def test_wait_for_activity_stop_from_signal(pg_connector, kill_own_pid):
     """
     pg_app = app.App(connector=pg_connector)
     worker = worker_module.Worker(app=pg_app, timeout=2)
-    task = asyncio.create_task(worker.run())
+    task = asyncio.ensure_future(worker.run())
     await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
     kill_own_pid()
@@ -69,7 +69,7 @@ async def test_wait_for_activity_stop(pg_connector):
     """
     pg_app = app.App(connector=pg_connector)
     worker = worker_module.Worker(app=pg_app, timeout=2)
-    task = asyncio.create_task(worker.run())
+    task = asyncio.ensure_future(worker.run())
     await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
     worker.stop()

--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -2,7 +2,8 @@ import asyncio
 
 import pytest
 
-from procrastinate import worker as worker_module, app
+from procrastinate import app
+from procrastinate import worker as worker_module
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -1,35 +1,27 @@
 import asyncio
-import time
 
 import pytest
 
-from procrastinate import App, jobs, store
+from procrastinate import worker as worker_module, app
 
 
 @pytest.mark.asyncio
 async def test_wait_for_activity(pg_connector):
     """
-    Testing that a new job arriving in the queue interrupts the wait
+    Testing that a new event interrupts the wait
     """
-    pg_connector.socket_timeout = 2
-    job_store = store.JobStore(connector=pg_connector)
-    await job_store.listen_for_jobs()
+    pg_app = app.App(connector=pg_connector)
+    worker = worker_module.Worker(app=pg_app, timeout=2)
+    task = asyncio.create_task(worker.single_worker())
+    await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
-    async def defer_job():
-        await asyncio.sleep(0.5)
-        await job_store.defer_job(
-            jobs.Job(id=0, queue="yay", task_name="oh", lock="sher", task_kwargs={})
-        )
+    worker.stop_requested = True
+    worker.notify_event.set()
 
-    before = time.perf_counter()
-    await asyncio.gather(pg_connector.wait_for_activity(), defer_job())
-    after = time.perf_counter()
-
-    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
-    assert after - before < 1
-
-    # We *did* create a job
-    assert await job_store.fetch_job(queues=None)
+    try:
+        await asyncio.wait_for(task, timeout=0.2)
+    except asyncio.TimeoutError:
+        pytest.fail("Failed to stop worker within .2s")
 
 
 @pytest.mark.asyncio
@@ -37,13 +29,18 @@ async def test_wait_for_activity_timeout(pg_connector):
     """
     Testing that we timeout if nothing happens
     """
-    pg_connector.socket_timeout = 0.01
+    pg_app = app.App(connector=pg_connector)
+    worker = worker_module.Worker(app=pg_app, timeout=2)
+    task = asyncio.create_task(worker.single_worker())
+    try:
+        await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
-    before = time.perf_counter()
-    await pg_connector.wait_for_activity()
-    after = time.perf_counter()
+        worker.stop_requested = True
 
-    assert after - before < 0.1
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(task, timeout=0.2)
+    finally:
+        worker.notify_event.set()
 
 
 @pytest.mark.asyncio
@@ -51,39 +48,32 @@ async def test_wait_for_activity_stop_from_signal(pg_connector, kill_own_pid):
     """
     Testing than ctrl+c interrupts the wait
     """
-    pg_connector.socket_timeout = 2
-    app = App(connector=pg_connector)
+    pg_app = app.App(connector=pg_connector)
+    worker = worker_module.Worker(app=pg_app, timeout=2)
+    task = asyncio.create_task(worker.run())
+    await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
-    async def stop():
-        await asyncio.sleep(0.5)
-        kill_own_pid()
+    kill_own_pid()
 
-    before = time.perf_counter()
-    await asyncio.gather(app.run_worker_async(), stop())
-    after = time.perf_counter()
-
-    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
-    assert after - before < 1
+    try:
+        await asyncio.wait_for(task, timeout=0.2)
+    except asyncio.TimeoutError:
+        pytest.fail("Failed to stop worker within .2s")
 
 
 @pytest.mark.asyncio
-async def test_wait_for_activity_stop_from_pipe(pg_connector):
+async def test_wait_for_activity_stop(pg_connector):
     """
     Testing than calling job_store.stop() interrupts the wait
     """
-    # This is a sub-case from above but we never know.
-    pg_connector.socket_timeout = 2
-    job_store = store.JobStore(connector=pg_connector)
+    pg_app = app.App(connector=pg_connector)
+    worker = worker_module.Worker(app=pg_app, timeout=2)
+    task = asyncio.create_task(worker.run())
+    await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
-    await job_store.listen_for_jobs()
+    worker.stop()
 
-    async def stop():
-        await asyncio.sleep(0.5)
-        pg_connector.interrupt_wait()
-
-    before = time.perf_counter()
-    await asyncio.gather(pg_connector.wait_for_activity(), stop())
-    after = time.perf_counter()
-
-    # If we wait less than 1 sec, it means the wait didn't reach the timeout.
-    assert after - before < 1
+    try:
+        await asyncio.wait_for(task, timeout=0.2)
+    except asyncio.TimeoutError:
+        pytest.fail("Failed to stop worker within .2s")

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -1,0 +1,75 @@
+import asyncio
+
+import pytest
+
+from procrastinate import worker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def running_worker(app):
+    running_worker = worker.Worker(app=app, queues=["some_queue"])
+    task = asyncio.create_task(running_worker.run())
+    running_worker.task = task
+    yield running_worker
+    running_worker.stop()
+    await asyncio.wait([task], timeout=0.5)
+
+
+async def test_run(app, running_worker, caplog):
+    caplog.set_level("DEBUG")
+
+    done = asyncio.Event()
+
+    @app.task(queue="some_queue")
+    def t():
+        done.set()
+
+    await t.configure().defer_async()
+
+    try:
+        await asyncio.wait_for(done.wait(), timeout=0.5)
+    except asyncio.TimeoutError:
+        pytest.fail("Failed to launch task withing .5s")
+
+    assert [q[0] for q in app.connector.queries] == [
+        "fetch_job",
+        "defer_job",
+        "fetch_job",
+        "finish_job",
+        "fetch_job",
+    ]
+
+    assert [(r.levelname, r.action) for r in caplog.records] == [
+        ("DEBUG", "register_queue"),
+        ("DEBUG", "about_to_job_defer"),
+        ("INFO", "job_defer"),
+        ("DEBUG", "loaded_job_info"),
+        ("INFO", "start_job"),
+        ("INFO", "job_success"),
+        ("DEBUG", "finish_task"),
+        ("DEBUG", "waiting_for_jobs"),
+    ]
+
+
+async def test_run_log_current_job_when_stopping(app, running_worker, caplog):
+    caplog.set_level("DEBUG")
+
+    @app.task(queue="some_queue")
+    async def t():
+        running_worker.stop()
+
+    await t.configure(lock="sher").defer_async()
+
+    try:
+        await asyncio.wait_for(running_worker.task, timeout=0.5)
+    except asyncio.TimeoutError:
+        pytest.fail("Failed to launch task withing .5s")
+
+    # We want to make sure that the log that names the current running task fired.
+    record = next(iter(r for r in caplog.records if r.action == "stopping_worker"))
+    assert (
+        record.message == "Stop requested, waiting for job to finish: "
+        "tests.integration.test_worker.t()"
+    )

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture
 async def running_worker(app):
     running_worker = worker.Worker(app=app, queues=["some_queue"])
-    task = asyncio.create_task(running_worker.run())
+    task = asyncio.ensure_future(running_worker.run())
     running_worker.task = task
     yield running_worker
     running_worker.stop()

--- a/tests/unit/test_aiopg_connector.py
+++ b/tests/unit/test_aiopg_connector.py
@@ -3,8 +3,12 @@ import pytest
 import procrastinate
 
 
-def test_app_deprecation(caplog):
+def test_app_deprecation(caplog, mocker):
+    connector = mocker.patch(
+        "procrastinate.aiopg_connector.PostgresConnector.create_with_pool"
+    )
     with pytest.deprecated_call():
         procrastinate.PostgresJobStore()
     assert caplog.records[0].levelname == "WARNING"
     assert caplog.records[0].message.startswith("Deprecation Warning")
+    connector.assert_called()

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -80,9 +80,12 @@ def test_app_register_queue_already_exists(app):
 def test_app_worker(app, mocker):
     Worker = mocker.patch("procrastinate.worker.Worker")
 
-    app._worker(queues=["yay"], name="w1")
+    app.worker_timeout = 12
+    app._worker(queues=["yay"], name="w1", wait=False)
 
-    Worker.assert_called_once_with(queues=["yay"], app=app, name="w1")
+    Worker.assert_called_once_with(
+        queues=["yay"], app=app, name="w1", timeout=12, wait=False,
+    )
 
 
 def test_app_run_worker(app, mocker):
@@ -91,18 +94,6 @@ def test_app_run_worker(app, mocker):
     app.run_worker(queues=["yay"])
 
     run.assert_called_once_with()
-
-
-def test_app_run_worker_only_once(app):
-    @app.task
-    def yay():
-        pass
-
-    yay.defer()
-
-    assert len(app.connector.finished_jobs) == 0
-    app.run_worker(only_once=True)
-    assert len(app.connector.finished_jobs) == 1
 
 
 def test_from_path(mocker):

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_close(connector):
+    connector.close()
+
+
+@pytest.mark.asyncio
+async def test_close_async(connector):
+    await connector.close_async()

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -6,8 +6,9 @@ import pytest
 from procrastinate import signals
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("one_signal", [signal.SIGINT, signal.SIGTERM])
-def test_on_stop(one_signal, kill_own_pid):
+async def test_on_stop_async(one_signal, kill_own_pid):
     called = []
 
     def stop():
@@ -15,6 +16,22 @@ def test_on_stop(one_signal, kill_own_pid):
 
     before = signal.getsignal(one_signal)
 
+    with signals.on_stop(callback=stop):
+        kill_own_pid(signal=one_signal)
+        await asyncio.sleep(0.001)  # Signal takes some time to be processed.
+
+    assert called == [True]
+    assert signal.getsignal(one_signal) is before
+
+
+@pytest.mark.parametrize("one_signal", [signal.SIGINT, signal.SIGTERM])
+def test_on_stop_sync(one_signal, kill_own_pid):
+    called = []
+
+    def stop():
+        called.append(True)
+
+    before = signal.getsignal(one_signal)
     with signals.on_stop(callback=stop):
         kill_own_pid(signal=one_signal)
 
@@ -42,8 +59,18 @@ def test_on_stop_signal_twice(kill_own_pid):
             kill_own_pid(signal=signal.SIGINT)
 
 
+def test_on_stop_signal_unused(kill_own_pid):
+    before = signal.getsignal(signal.SIGINT)
+    with signals.on_stop(callback=lambda: None):
+        during = signal.getsignal(signal.SIGINT)
+    after = signal.getsignal(signal.SIGINT)
+
+    assert before is after
+    assert before is not during
+
+
 @pytest.mark.asyncio
-def test_on_stop_work_with_asyncio(kill_own_pid):
+async def test_on_stop_work_with_asyncio(kill_own_pid):
     # In this test, we want to make sure that interacting with synchronisation
     # primitives from within a signal handler works.
     event = asyncio.Event()
@@ -56,7 +83,7 @@ def test_on_stop_work_with_asyncio(kill_own_pid):
         kill_own_pid()
 
     try:
-        with signals.on_stop():
+        with signals.on_stop(stop):
             asyncio.create_task(wait_and_kill())
             await asyncio.wait_for(event.wait(), timeout=0.01)
     except asyncio.TimeoutError:

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -84,7 +84,7 @@ async def test_on_stop_work_with_asyncio(kill_own_pid):
 
     try:
         with signals.on_stop(stop):
-            asyncio.create_task(wait_and_kill())
+            asyncio.ensure_future(wait_and_kill())
             await asyncio.wait_for(event.wait(), timeout=0.01)
     except asyncio.TimeoutError:
         pytest.fail("Signal did not awake coroutine")

--- a/tests/unit/test_signals.py
+++ b/tests/unit/test_signals.py
@@ -1,3 +1,4 @@
+import asyncio
 import signal
 
 import pytest
@@ -9,7 +10,7 @@ from procrastinate import signals
 def test_on_stop(one_signal, kill_own_pid):
     called = []
 
-    def stop(*args):
+    def stop():
         called.append(True)
 
     before = signal.getsignal(one_signal)
@@ -32,3 +33,31 @@ def test_do_nothing_on_secondary_thread(mocker):
         pass
 
     signal.assert_not_called()
+
+
+def test_on_stop_signal_twice(kill_own_pid):
+    with pytest.raises(KeyboardInterrupt):
+        with signals.on_stop(callback=lambda: None):
+            kill_own_pid(signal=signal.SIGINT)
+            kill_own_pid(signal=signal.SIGINT)
+
+
+@pytest.mark.asyncio
+def test_on_stop_work_with_asyncio(kill_own_pid):
+    # In this test, we want to make sure that interacting with synchronisation
+    # primitives from within a signal handler works.
+    event = asyncio.Event()
+
+    def stop():
+        event.set()
+
+    async def wait_and_kill():
+        await asyncio.sleep(0.001)
+        kill_own_pid()
+
+    try:
+        with signals.on_stop():
+            asyncio.create_task(wait_and_kill())
+            await asyncio.wait_for(event.wait(), timeout=0.01)
+    except asyncio.TimeoutError:
+        pytest.fail("Signal did not awake coroutine")

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -88,5 +88,8 @@ async def test_finish_job(job_store, job_factory, connector):
     ],
 )
 async def test_listen_for_jobs(job_store, connector, mocker, queues, channels):
-    await job_store.listen_for_jobs(queues)
-    assert connector.queries == [("listen_for_jobs", channel) for channel in channels]
+    event = mocker.Mock()
+
+    await job_store.listen_for_jobs(queues=queues, event=event)
+    assert connector.notify_event is event
+    assert connector.notify_channels == channels

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -255,20 +255,9 @@ def test_finish_job_run_retry_no_schedule(connector):
     assert len(connector.events[id]) == 3
 
 
-@pytest.mark.asyncio
-async def test_wait_for_activity(connector):
-    # If we don't crash, it's enough
-    await connector.wait_for_activity()
-
-
 def test_apply_schema_run(connector):
     # If we don't crash, it's enough
     connector.apply_schema_run()
-
-
-def test_stop(connector):
-    # If we don't crash, it's enough
-    connector.stop()
 
 
 def test_listen_for_jobs_run(connector):

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pendulum
 import pytest
 
@@ -263,3 +265,16 @@ def test_apply_schema_run(connector):
 def test_listen_for_jobs_run(connector):
     # If we don't crash, it's enough
     connector.listen_for_jobs_run()
+
+
+@pytest.mark.asyncio
+async def test_defer_no_notify(connector):
+    # This test is there to check that if the defered queue doesn't match the
+    # listened queue, the testing connector doesn't notify.
+    event = asyncio.Event()
+    await connector.listen_notify(event=event, channels="some_other_channel")
+    connector.defer_job_one(
+        task_name="foo", lock="bar", args={}, scheduled_at=None, queue="baz"
+    )
+
+    assert not event.is_set()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -94,3 +94,61 @@ async def test_add_sync_api_does_not_break_original_coroutine():
     await Test().a_async()
 
     assert result == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_add_sync_api_classmethods_async():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @classmethod
+        async def a_async(cls, value):
+            result.extend([cls, value])
+
+    await Test.a_async("async")
+
+    assert result == [Test, "async"]
+
+
+def test_add_sync_api_classmethods_sync():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @classmethod
+        async def a_async(cls, value):
+            result.extend([cls, value])
+
+    Test.a("sync")
+
+    assert result == [Test, "sync"]
+
+
+@pytest.mark.asyncio
+async def test_add_sync_api_staticmethods_async():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @staticmethod
+        async def a_async(value):
+            result.append(value)
+
+    await Test.a_async("async")
+
+    assert result == ["async"]
+
+
+def test_add_sync_api_staticmethods_sync():
+    result = []
+
+    @utils.add_sync_api
+    class Test:
+        @staticmethod
+        async def a_async(value):
+            result.append(value)
+
+    Test.a("sync")
+
+    assert result == ["sync"]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -152,3 +152,18 @@ def test_add_sync_api_staticmethods_sync():
     Test.a("sync")
 
     assert result == ["sync"]
+
+
+def test_add_sync_api_invalid():
+    # This test gives the decorator an object that looks like an async method
+    # but is not. Given it's neither a method nor a classmethod nor a staticmethod
+    # but a NotAMethod(), it should be detected as such.
+    class NotAMethod:
+        async def __func__():
+            pass
+
+    with pytest.raises(ValueError):
+
+        @utils.add_sync_api
+        class Test:
+            a_async = NotAMethod()


### PR DESCRIPTION
Closes #148
Closes #166 

Sorry 100000000 times @elemoine 

### Successful PR Checklist:
- [ ] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [ ] Had a good time contributing? (if not, feel free to give some feedback)
