### PR TITLE
Closes instead of Cf. in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Cf. #<ticket number>
+Closes #<ticket number>
 
 ### Successful PR Checklist:
 - [ ] Tests


### PR DESCRIPTION
Just a small change in the PR template, because the large majority of our PRs close a ticket, so the risk or error is low.