### PR TITLE
Create Aiopg pool lazily

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -20,11 +20,8 @@ are accessible through :py:attr:`App.builtin_tasks`:
 Connectors
 ----------
 
-.. This does not indicate that create_with_pool* is an async classmethod because of
-   https://github.com/sphinx-doc/sphinx/issues/7189
-
 .. autoclass:: procrastinate.PostgresConnector
-    :members: create_with_pool, create_with_pool_async, close, close_async
+    :members: create_with_pool, close, close_async
 
 .. autoclass:: procrastinate.testing.InMemoryConnector
     :members: reset

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,9 +84,7 @@ async def connection(connection_params):
 
 @pytest.fixture
 async def pg_connector(connection_params):
-    connector = await aiopg_connector.PostgresConnector.create_with_pool_async(
-        **connection_params
-    )
+    connector = aiopg_connector.PostgresConnector.create_with_pool(**connection_params)
     yield connector
     await connector.close_async()
 


### PR DESCRIPTION
I was playing with the new pools (cf #173) in my project, and I had a few issues with the new design.

In order to create an App, I need a Connector. And in order to create a Connector, I either need to create my own pool, or to use `PosgresConnector.create_with_pool_async` which will create one for me. This has two implications:
- I can't create a pool without an event loop, so I can't instantiate an App before starting my event loop. Instantiating an App usually happen very early (before defining tasks), so it should not have the side effect of creating an event loop, nor require one.
- I can't instantiate an App without connecting to my DB. I like to be able to start my services without a DB connection for resiliency. This makes it close to impossible. Also it's very simple to end up in a situation where you have side-effects at import time, which is usually a bad idea.

So I've tried to mess around a bit with the `PostgresConnector` in order to create the loop lazily, like the connection is in Procrastinate 0.6. My solution is probably not perfect, and it will require some doc changes (but the current doc is not up-to-date with master anyway).

Please let me now what you think :) .  

### Successful PR Checklist:
- [ ] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [ ] Had a good time contributing? (if not, feel free to give some feedback)
