### PR TITLE
Added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+
+[*.py]
+quote_type = double
+max_line_length = 88
+
+[*.rst]
+max_line_length = 88
+
+[*.yml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -183,6 +183,12 @@ If ``tox`` is installed inside your ``virtualenv``, you may want to activate the
 
 This will keep you from creating a commit if there's a linting problem.
 
+In addition, an editorconfig_ file will help your favorite editor to respect
+procrastinate coding style. It is automatically used by most famous IDEs, such as
+Pycharm and VS Code.
+
+.. _editorconfig: https://editorconfig.org/
+
 Build the documentation
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,15 @@
 prune tests
 prune docs
 prune procrastinate_demo
-exclude requirements.txt
-exclude CONTRIBUTING.rst
-exclude CHANGELOG.rst
-exclude CODE_OF_CONDUCT.md
-exclude docker-compose.yml
-exclude tox.ini
-exclude pre-commit-hook
-recursive-include procrastinate *.sql
 include LICENSE.rst
 include VERSION.txt
+exclude .editorconfig
+exclude CHANGELOG.rst
+exclude CODE_OF_CONDUCT.md
+exclude CONTRIBUTING.rst
+exclude docker-compose.yml
 exclude Dockerfile
+exclude pre-commit-hook
+exclude requirements.txt
+exclude tox.ini
+recursive-include procrastinate *.sql


### PR DESCRIPTION
Closes #137

### Successful PR Checklist:
- [X] Tests
- [ ] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [X] Had a good time contributing? (if not, feel free to give some feedback)

This PR adds an editorconfig to the project. It is inspired by Django [editorconfig](https://github.com/django/django/blob/master/.editorconfig), and adds some extra options to better fit black requirements. 

Those extra options are : 
* `quote_type: double`, defined in editorconfig doc, yet not very well supported yet
* `continuation_indent_size: 4`, defined in editorconfig doc, and supported by Pycharm :tada: 

Unfortunately no other option seems relevant. Please let me know if you know others.
