### PR TITLE
Create and use a decorator to wrap aiopg and pyscop2 erros as connect…

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -5,7 +5,7 @@ App
 ---
 
 .. autoclass:: procrastinate.App
-    :members: task, run_worker, configure_task
+    :members: task, run_worker, configure_task, from_path
 
 App.builtin_tasks
 """""""""""""""""
@@ -51,3 +51,11 @@ Retry strategies
 
 .. autoclass:: procrastinate.BaseRetryStrategy
     :members: get_schedule_in
+
+
+Exceptions
+----------
+
+.. automodule:: procrastinate.exceptions
+    :members: ProcrastinateException, PoolAlreadySet, LoadFromPathError,
+              ConnectorException

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -49,8 +49,8 @@ class PostgresConnector(connector.BaseConnector):
         py:func:`PostgresConnector.set_pool` method.
 
         All other arguments than ``json_dumps`` and ``json_loads`` are passed to
-        ``aiopg.create_pool`` (see aiopg documentation__), with default values that
-        may differ from those of ``aiopg`` (see the list of parameters below).
+        :py:func:`aiopg.create_pool` (see aiopg documentation__), with default values
+        that may differ from those of ``aiopg`` (see the list of parameters below).
 
         .. _psycopg2 doc: https://www.psycopg.org/docs/extras.html#json-adaptation
         .. __: https://aiopg.readthedocs.io/en/stable/core.html#aiopg.create_pool

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -30,6 +30,8 @@ def wrap_exceptions(coro: CoroutineFunction) -> CoroutineFunction:
         except psycopg2.Error as exc:
             raise exceptions.ConnectorException from exc
 
+    # Attaching a custom attribute to ease testability and make the
+    # decorator more introspectable
     wrapped._exceptions_wrapped = True  # type: ignore
     return wrapped
 

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -30,6 +30,7 @@ def wrap_exceptions(coro: CoroutineFunction) -> CoroutineFunction:
         except psycopg2.Error as exc:
             raise exceptions.ConnectorException from exc
 
+    wrapped._exceptions_wrapped = True  # type: ignore
     return wrapped
 
 

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -28,7 +28,17 @@ class App:
     """
 
     @classmethod
-    def from_path(cls, dotted_path: str):
+    def from_path(cls, dotted_path: str) -> "App":
+        """
+        Create an :py:class:`App` object by dynamically loading the
+        object at the given path.
+
+        Parameters
+        ----------
+        dotted_path :
+            Dotted path to the object to load (e.g.
+            ``mymodule.submodule.procrastinate_app``)
+        """
         return utils.load_from_path(dotted_path, cls)
 
     def __init__(

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -23,9 +23,6 @@ class BaseConnector:
     ) -> List[Dict[str, Any]]:
         raise NotImplementedError
 
-    def make_dynamic_query(self, query: str, **identifiers: str) -> str:
-        raise NotImplementedError
-
     async def listen_notify(
         self, event: asyncio.Event, channels: Iterable[str]
     ) -> None:

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -24,3 +24,7 @@ class JobRetry(ProcrastinateException):
 
 class PoolAlreadySet(ProcrastinateException):
     pass
+
+
+class ConnectorException(ProcrastinateException):
+    pass

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -2,6 +2,10 @@ import datetime
 
 
 class ProcrastinateException(Exception):
+    """
+    Base type for all Procrastinate exceptions
+    """
+
     pass
 
 
@@ -14,7 +18,10 @@ class JobError(ProcrastinateException):
 
 
 class LoadFromPathError(ImportError, ProcrastinateException):
-    pass
+    """
+    Raised when calling :py:func:`procrastinate.App.from_path`
+    when the app is not found or the object is not an App.
+    """
 
 
 class JobRetry(ProcrastinateException):
@@ -23,8 +30,19 @@ class JobRetry(ProcrastinateException):
 
 
 class PoolAlreadySet(ProcrastinateException):
+    """
+    Indicates a call on connector.set_pool() was done but the
+    pool already had a set. Changing the pool of a connector is not
+    permitted.
+    """
+
     pass
 
 
 class ConnectorException(ProcrastinateException):
+    """
+    Any kind of database error will be raised as this type.
+    The precise error can be seen with ``exception.__cause__``
+    """
+
     pass

--- a/tests/unit/test_aiopg_connector.py
+++ b/tests/unit/test_aiopg_connector.py
@@ -1,6 +1,7 @@
+import psycopg2
 import pytest
 
-from procrastinate import aiopg_connector
+from procrastinate import aiopg_connector, exceptions
 
 
 @pytest.mark.asyncio
@@ -28,3 +29,42 @@ def test_adapt_pool_args_maxsize():
     )
 
     assert args["maxsize"] == 2
+
+
+@pytest.mark.asyncio
+async def test_wrap_exceptions_wraps():
+    @aiopg_connector.wrap_exceptions
+    async def corofunc():
+        raise psycopg2.DatabaseError
+
+    coro = corofunc()
+
+    with pytest.raises(exceptions.ConnectorException):
+        await coro
+
+
+@pytest.mark.asyncio
+async def test_wrap_exceptions_success():
+    @aiopg_connector.wrap_exceptions
+    async def corofunc(a, b):
+        return a, b
+
+    assert await corofunc(1, 2) == (1, 2)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "close_async",
+        "_create_pool",
+        "execute_query",
+        "_execute_query_connection",
+        "execute_query_one",
+        "execute_query_all",
+        "listen_notify",
+        "_loop_notify",
+    ],
+)
+def test_wrap_exceptions_applied(method_name):
+    connector = aiopg_connector.PostgresConnector()
+    assert getattr(connector, method_name)._exceptions_wrapped is True


### PR DESCRIPTION
Closes #140 

### Successful PR Checklist:
- [x] Tests
- [x] Documentation (optionally: [run spell checking](https://github.com/peopledoc/procrastinate/blob/master/CONTRIBUTING.rst#build-the-documentation))
- [x] Had a good time contributing? (if not, feel free to give some feedback)

This PR adds a decorator to wrap psycopg2 and aiopg errors as connector exceptions. This decorator is expected to be used on coroutine functions only. It has been used on PostgresConnector methods doing psycopg2 or aiopg potential errors

