### PR TITLE
Fix procrastinate_fetch_job

### DIFF
--- a/procrastinate/sql/migrations/delta_0.6.0_001_fix_procrastinate_fetch_job.sql
+++ b/procrastinate/sql/migrations/delta_0.6.0_001_fix_procrastinate_fetch_job.sql
@@ -1,0 +1,34 @@
+-- fix procrastinate_fetch_job that works by accident, now returning a proper
+-- procrastinate_jobs row
+CREATE FUNCTION procrastinate_fetch_job(target_queue_names character varying[]) RETURNS procrastinate_jobs
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+	found_jobs procrastinate_jobs;
+BEGIN
+	WITH potential_job AS (
+		SELECT procrastinate_jobs.*
+			FROM procrastinate_jobs
+			LEFT JOIN procrastinate_job_locks ON procrastinate_job_locks.object = procrastinate_jobs.lock
+			WHERE (target_queue_names IS NULL OR queue_name = ANY( target_queue_names ))
+			  AND procrastinate_job_locks.object IS NULL
+			  AND status = 'todo'
+			  AND (scheduled_at IS NULL OR scheduled_at <= now())
+            ORDER BY id ASC
+			FOR UPDATE OF procrastinate_jobs SKIP LOCKED LIMIT 1
+	), lock_object AS (
+		INSERT INTO procrastinate_job_locks
+			SELECT lock FROM potential_job
+            ON CONFLICT DO NOTHING
+            RETURNING object
+	)
+	UPDATE procrastinate_jobs
+		SET status = 'doing'
+		FROM potential_job, lock_object
+        WHERE lock_object.object IS NOT NULL
+		AND procrastinate_jobs.id = potential_job.id
+		RETURNING procrastinate_jobs.* INTO found_jobs;
+
+	RETURN found_jobs;
+END;
+$$;

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -69,7 +69,7 @@ BEGIN
 		FROM potential_job, lock_object
         WHERE lock_object.object IS NOT NULL
 		AND procrastinate_jobs.id = potential_job.id
-		RETURNING * INTO found_jobs;
+		RETURNING procrastinate_jobs.* INTO found_jobs;
 
 	RETURN found_jobs;
 END;


### PR DESCRIPTION
This function works as is, but because of a side effect: when storing a
record into a composite type, if there are more attributes than
necessary, the remaining attributes are simply lost. So it worked
because the columns came from the query in the same order as needed by
the composite type. With this commit, no side effect anymore.

Closes no ticket. We detected this on our schemas because we started linting plpgsql in all our functions, using plpgsql_check