### PR TITLE
Use CREATE OR REPLACE FUNCTION in migration script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@ Closes #<ticket number>
 
 <!-- Please do not remove this, even if you think you don't need it -->
 ### Successful PR Checklist:
-<!-- In case of doubt, we're here to help. CONTIRBUTING.md might help too -->
+<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
 - [ ] Tests
   - [ ] (not applicable?)
 - [ ] Documentation

--- a/procrastinate/sql/migrations/delta_0.6.0_001_fix_procrastinate_fetch_job.sql
+++ b/procrastinate/sql/migrations/delta_0.6.0_001_fix_procrastinate_fetch_job.sql
@@ -1,6 +1,6 @@
 -- fix procrastinate_fetch_job that works by accident, now returning a proper
 -- procrastinate_jobs row
-CREATE FUNCTION procrastinate_fetch_job(target_queue_names character varying[]) RETURNS procrastinate_jobs
+CREATE OR REPLACE FUNCTION procrastinate_fetch_job(target_queue_names character varying[]) RETURNS procrastinate_jobs
     LANGUAGE plpgsql
     AS $$
 DECLARE


### PR DESCRIPTION
This PR updates the `delta_0.6.0_001_fix_procrastinate_fetch_job.sql` migration script to use `CREATE OR REPLACE FUNCTION` rather than `CREATE FUNCTION`.


<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTIRBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
