### PR TITLE
Worker should instantiate Event lazily, and should use wait_for, not wait

### DIFF
--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -102,8 +102,14 @@ class Worker:
                     },
                 )
                 self.notify_event.clear()
-                await asyncio.wait([self.notify_event.wait()], timeout=self.timeout)
-                self.notify_event.clear()
+                try:
+                    await asyncio.wait_for(
+                        self.notify_event.wait(), timeout=self.timeout
+                    )
+                    self.notify_event.clear()
+                except TimeoutError:
+                    pass
+
                 continue
             await self.process_job(job=job)
 

--- a/tests/integration/test_wait_stop.py
+++ b/tests/integration/test_wait_stop.py
@@ -13,6 +13,7 @@ async def test_wait_for_activity(pg_connector):
     """
     pg_app = app.App(connector=pg_connector)
     worker = worker_module.Worker(app=pg_app, timeout=2)
+    worker.notify_event = asyncio.Event()
     task = asyncio.ensure_future(worker.single_worker())
     await asyncio.sleep(0.2)  # should be enough so that we're waiting
 
@@ -32,6 +33,7 @@ async def test_wait_for_activity_timeout(pg_connector):
     """
     pg_app = app.App(connector=pg_connector)
     worker = worker_module.Worker(app=pg_app, timeout=2)
+    worker.notify_event = asyncio.Event()
     task = asyncio.ensure_future(worker.single_worker())
     try:
         await asyncio.sleep(0.2)  # should be enough so that we're waiting

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -14,7 +14,7 @@ async def running_worker(app):
     running_worker.task = task
     yield running_worker
     running_worker.stop()
-    await asyncio.wait([task], timeout=0.5)
+    await asyncio.wait_for(task, timeout=0.5)
 
 
 async def test_run(app, running_worker, caplog):

--- a/tests/unit/test_aiopg_connector.py
+++ b/tests/unit/test_aiopg_connector.py
@@ -68,3 +68,21 @@ async def test_wrap_exceptions_success():
 def test_wrap_exceptions_applied(method_name):
     connector = aiopg_connector.PostgresConnector()
     assert getattr(connector, method_name)._exceptions_wrapped is True
+
+
+def test_set_pool(mocker):
+    pool = mocker.Mock()
+    connector = aiopg_connector.PostgresConnector()
+
+    connector.set_pool(pool)
+
+    assert connector._pool is pool
+
+
+def test_set_pool_already_set(mocker):
+    pool = mocker.Mock()
+    connector = aiopg_connector.PostgresConnector()
+    connector.set_pool(pool)
+
+    with pytest.raises(exceptions.PoolAlreadySet):
+        connector.set_pool(pool)

--- a/tests/unit/test_worker_sync.py
+++ b/tests/unit/test_worker_sync.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from procrastinate import exceptions, worker
@@ -65,6 +67,7 @@ def test_queues_display(queues, result):
 
 def test_stop(test_worker, caplog):
     caplog.set_level("INFO")
+    test_worker.notify_event = asyncio.Event()
 
     test_worker.stop()
 
@@ -76,6 +79,7 @@ def test_stop(test_worker, caplog):
 def test_stop_log_job(test_worker, caplog):
     caplog.set_level("INFO")
     test_worker.current_job_context = {"call_string": "yay()"}
+    test_worker.notify_event = asyncio.Event()
 
     test_worker.stop()
 


### PR DESCRIPTION
Closes #201 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing? < kinda. Not astonishing. Our tests there are a bit complicated but it's still the best we could imagine.
