### PR TITLE
Add a schema migration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
           - postgresql-client-10
       python: 3.6
       env:
-        TOX_ENV: py36-unit-tests,py36-integration-tests,py36-acceptance-tests
+        TOX_ENV: py36-unit-tests,py36-integration-tests,py36-acceptance-tests,py36-migration-tests
 
     - python: 3.7
       addons:
@@ -41,7 +41,7 @@ jobs:
           - postgresql-10
           - postgresql-client-10
       env:
-        TOX_ENV: py37-unit-tests,py37-integration-tests,py37-acceptance-tests
+        TOX_ENV: py37-unit-tests,py37-integration-tests,py37-acceptance-tests,py37-migration-tests
 
     - python: 3.8
       addons:
@@ -51,7 +51,7 @@ jobs:
           - postgresql-10
           - postgresql-client-10
       env:
-        TOX_ENV: py38-unit-tests,py38-integration-tests,py38-acceptance-tests
+        TOX_ENV: py38-unit-tests,py38-integration-tests,py38-acceptance-tests,py38-migration-tests
 
     - python: 3.8
       env:

--- a/procrastinate/sql/migrations/baseline-0.5.0.sql
+++ b/procrastinate/sql/migrations/baseline-0.5.0.sql
@@ -1,0 +1,187 @@
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+CREATE TABLE IF NOT EXISTS procrastinate_version (
+    id BIGSERIAL PRIMARY KEY,
+    version TEXT,
+    name TEXT,
+    applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TYPE procrastinate_job_status AS ENUM (
+    'todo',  -- The job is queued
+    'doing',  -- The job has been fetched by a worker
+    'succeeded',  -- The job ended succesfully
+    'failed'  -- The job ended with an error
+);
+
+CREATE TYPE procrastinate_job_event_type AS ENUM (
+    'deferred',  -- Job created, in todo
+    'started',  -- todo -> doing
+    'deferred_for_retry',  -- doing -> todo
+    'failed',  -- doing -> failed
+    'succeeded',  -- doing -> succeeded
+    'cancelled', -- todo -> failed or succeeded
+    'scheduled' -- not an event transition, but recording when a task is scheduled for
+);
+
+CREATE TABLE procrastinate_jobs (
+    id bigserial PRIMARY KEY,
+    queue_name character varying(128) NOT NULL,
+    task_name character varying(128) NOT NULL,
+    lock text,
+    args jsonb DEFAULT '{}' NOT NULL,
+    status procrastinate_job_status DEFAULT 'todo'::procrastinate_job_status NOT NULL,
+    scheduled_at timestamp with time zone NULL,
+    started_at timestamp with time zone NULL,
+    attempts integer DEFAULT 0 NOT NULL
+);
+
+CREATE TABLE procrastinate_events (
+    id BIGSERIAL PRIMARY KEY,
+    job_id integer NOT NULL REFERENCES procrastinate_jobs ON DELETE CASCADE,
+    type procrastinate_job_event_type,
+    at timestamp with time zone DEFAULT NOW() NULL
+);
+
+CREATE TABLE procrastinate_job_locks (
+    object text PRIMARY KEY
+);
+
+CREATE FUNCTION procrastinate_fetch_job(target_queue_names character varying[]) RETURNS procrastinate_jobs
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+	found_jobs procrastinate_jobs;
+BEGIN
+	WITH potential_job AS (
+		SELECT procrastinate_jobs.*
+			FROM procrastinate_jobs
+			LEFT JOIN procrastinate_job_locks ON procrastinate_job_locks.object = procrastinate_jobs.lock
+			WHERE (target_queue_names IS NULL OR queue_name = ANY( target_queue_names ))
+			  AND procrastinate_job_locks.object IS NULL
+			  AND status = 'todo'
+			  AND (scheduled_at IS NULL OR scheduled_at <= now())
+            ORDER BY id ASC
+			FOR UPDATE OF procrastinate_jobs SKIP LOCKED LIMIT 1
+	), lock_object AS (
+		INSERT INTO procrastinate_job_locks
+			SELECT lock FROM potential_job
+            ON CONFLICT DO NOTHING
+            RETURNING object
+	)
+	UPDATE procrastinate_jobs
+		SET status = 'doing',
+            started_at = NOW()
+		FROM potential_job, lock_object
+        WHERE lock_object.object IS NOT NULL
+		AND procrastinate_jobs.id = potential_job.id
+		RETURNING * INTO found_jobs;
+
+	RETURN found_jobs;
+END;
+$$;
+
+CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+	WITH finished_job AS (
+		UPDATE procrastinate_jobs
+        SET status = end_status,
+            attempts = attempts + 1,
+            scheduled_at = COALESCE(next_scheduled_at, scheduled_at)
+        WHERE id = job_id RETURNING lock
+	)
+	DELETE FROM procrastinate_job_locks WHERE object = (SELECT lock FROM finished_job);
+END;
+$$;
+
+CREATE FUNCTION procrastinate_notify_queue() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+	PERFORM pg_notify('procrastinate_queue#' || NEW.queue_name, NEW.task_name);
+	PERFORM pg_notify('procrastinate_any_queue', NEW.task_name);
+	RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION procrastinate_trigger_status_events_procedure_insert() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO procrastinate_events(job_id, type)
+        VALUES (NEW.id, 'deferred'::procrastinate_job_event_type);
+	RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION procrastinate_trigger_status_events_procedure_update() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    WITH t AS (
+        SELECT CASE
+            WHEN OLD.status = 'todo'::procrastinate_job_status
+                AND NEW.status = 'doing'::procrastinate_job_status
+                THEN 'started'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'todo'::procrastinate_job_status
+                THEN 'deferred_for_retry'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'failed'::procrastinate_job_status
+                THEN 'failed'::procrastinate_job_event_type
+            WHEN OLD.status = 'doing'::procrastinate_job_status
+                AND NEW.status = 'succeeded'::procrastinate_job_status
+                THEN 'succeeded'::procrastinate_job_event_type
+            WHEN OLD.status = 'todo'::procrastinate_job_status
+                AND (
+                    NEW.status = 'failed'::procrastinate_job_status
+                    OR NEW.status = 'succeeded'::procrastinate_job_status
+                )
+                THEN 'cancelled'::procrastinate_job_event_type
+            ELSE NULL
+        END as event_type
+    )
+    INSERT INTO procrastinate_events(job_id, type)
+        SELECT NEW.id, t.event_type
+        FROM t
+        WHERE t.event_type IS NOT NULL;
+	RETURN NEW;
+END;
+$$;
+
+CREATE FUNCTION procrastinate_trigger_scheduled_events_procedure() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    INSERT INTO procrastinate_events(job_id, type, at)
+        VALUES (NEW.id, 'scheduled'::procrastinate_job_event_type, NEW.scheduled_at);
+
+	RETURN NEW;
+END;
+$$;
+
+CREATE INDEX ON procrastinate_jobs(queue_name);
+
+CREATE TRIGGER procrastinate_jobs_notify_queue
+    AFTER INSERT ON procrastinate_jobs
+    FOR EACH ROW WHEN ((new.status = 'todo'::procrastinate_job_status))
+    EXECUTE PROCEDURE procrastinate_notify_queue();
+
+CREATE TRIGGER procrastinate_trigger_status_events_update
+    AFTER UPDATE OF status ON procrastinate_jobs
+    FOR EACH ROW
+    EXECUTE PROCEDURE procrastinate_trigger_status_events_procedure_update();
+
+CREATE TRIGGER procrastinate_trigger_status_events_insert
+    AFTER INSERT ON procrastinate_jobs
+    FOR EACH ROW WHEN ((new.status = 'doing'::procrastinate_job_status))
+    EXECUTE PROCEDURE procrastinate_trigger_status_events_procedure_insert();
+
+CREATE TRIGGER procrastinate_trigger_scheduled_events
+    AFTER UPDATE OR INSERT ON procrastinate_jobs
+    FOR EACH ROW WHEN ((new.scheduled_at IS NOT NULL AND new.status = 'todo'::procrastinate_job_status))
+    EXECUTE PROCEDURE procrastinate_trigger_scheduled_events_procedure();
+
+CREATE INDEX procrastinate_events_job_id_fkey ON procrastinate_events(job_id);

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ test =
     pytest-cov
     pytest-click
     pytest-asyncio!=0.11.0
+    pum
 
 lint =
     black
@@ -95,6 +96,7 @@ testpaths =
     tests/unit
     tests/integration
     tests/acceptance
+    tests/migration
 
 [mypy-setuptools.*,psycopg2.*,pendulum.*,importlib_metadata.*,importlib_resources.*,aiopg.*]
 ignore_missing_imports = True

--- a/tests/migration/test_migration.py
+++ b/tests/migration/test_migration.py
@@ -1,0 +1,115 @@
+import os
+import subprocess
+from contextlib import closing
+
+import pkg_resources
+import psycopg2
+import pytest
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+from procrastinate import __version__, aiopg_connector, schema
+
+PG_SERVICES = """
+[procrastinate_test1]
+dbname=procrastinate_test1
+[procrastinate_test2]
+dbname=procrastinate_test2
+"""
+
+
+def _execute_sql(cursor, query, *identifiers):
+    cursor.execute(
+        sql.SQL(query).format(
+            *(sql.Identifier(identifier) for identifier in identifiers)
+        )
+    )
+
+
+@pytest.fixture
+def migrations_directory():
+    return pkg_resources.resource_filename("procrastinate", "sql/migrations")
+
+
+@pytest.fixture
+def procrastinate_version():
+    try:
+        idx = __version__.index("+")
+    except ValueError:
+        idx = None
+    return __version__[:idx]
+
+
+@pytest.fixture
+def pg_service_file(tmp_path):
+    file_path = tmp_path / "pg_service.conf"
+    with open(file_path, "w") as file_:
+        file_.write(PG_SERVICES)
+    yield file_path
+
+
+@pytest.fixture
+def environment(pg_service_file):
+    env = os.environ.copy()
+    env["PGSERVICEFILE"] = pg_service_file
+    return env
+
+
+@pytest.fixture
+def setup_databases(procrastinate_version, migrations_directory, environment):
+
+    # create the procrastinate_test1 and procrastinate_test2 databases
+    with closing(psycopg2.connect("", dbname="postgres")) as connection:
+        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with connection.cursor() as cursor:
+            _execute_sql(cursor, "DROP DATABASE IF EXISTS {}", "procrastinate_test1")
+            _execute_sql(cursor, "CREATE DATABASE {}", "procrastinate_test1")
+            _execute_sql(cursor, "DROP DATABASE IF EXISTS {}", "procrastinate_test2")
+            _execute_sql(cursor, "CREATE DATABASE {}", "procrastinate_test2")
+
+    # apply the procrastinate schema to procrastinate_test1
+    connector = aiopg_connector.PostgresConnector(dbname="procrastinate_test1")
+    schema_manager = schema.SchemaManager(connector=connector)
+    schema_manager.apply_schema()
+    connector.close()
+
+    # set the baseline version in procrastinate_test1
+    cmd = (
+        "pum baseline -p procrastinate_test1 -t public.pum "
+        f"-d {migrations_directory} -b {procrastinate_version}"
+    )
+    subprocess.run(cmd.split(), check=True, env=environment)
+
+    # apply the baseline schema to procrastinate_test2
+    cmd = f"psql -d procrastinate_test2 -f {migrations_directory}/baseline-0.5.0.sql"
+    subprocess.run(cmd.split(), check=True)
+
+    # set the baseline version in procrastinate_test2
+    cmd = (
+        f"pum baseline -p procrastinate_test2 -t public.pum -d {migrations_directory} "
+        "-b 0.5.0"
+    )
+    subprocess.run(cmd.split(), check=True, env=environment)
+
+    yield
+
+    with closing(psycopg2.connect("", dbname="postgres")) as connection:
+        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with connection.cursor() as cursor:
+            _execute_sql(cursor, "DROP DATABASE IF EXISTS {}", "procrastinate_test2")
+            _execute_sql(cursor, "DROP DATABASE IF EXISTS {}", "procrastinate_test1")
+
+
+def test_migration(setup_databases, migrations_directory, environment):
+    # apply the migrations on the procrastinate_test2 database
+    cmd = f"pum upgrade -p procrastinate_test2 -t public.pum -d {migrations_directory}"
+    subprocess.run(cmd.split(), check=True, env=environment)
+
+    # check that the databases procrastinate_test1 and procrastinate_test2 have
+    # the same schema
+    cmd = "pum check -p1 procrastinate_test1 -p2 procrastinate_test2 -v 2"
+    proc = subprocess.run(cmd.split(), env=environment, stdout=True, stderr=True)
+
+    # pum check exits with a non-zero return code if the databases don't have
+    # the same schema
+    assert proc.returncode == 0

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     unit-tests: pytest tests/unit {posargs}
     integration-tests: pytest tests/integration {posargs}
     acceptance-tests: pytest tests/acceptance {posargs}
+    migration-tests: pytest tests/migration {posargs}
 
 [testenv:check-lint]
 extras =


### PR DESCRIPTION
Closes #197 

This adds a migration test that checks that developers don't forget to write migration scripts when making changes to the procrastinate schema.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
