### PR TITLE
Improve job defer logs

### DIFF
--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -65,7 +65,7 @@ async def test_run_log_current_job_when_stopping(app, running_worker, caplog):
     try:
         await asyncio.wait_for(running_worker.task, timeout=0.5)
     except asyncio.TimeoutError:
-        pytest.fail("Failed to launch task withing .5s")
+        pytest.fail("Failed to launch task within .5s")
 
     # We want to make sure that the log that names the current running task fired.
     assert {

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -11,9 +11,9 @@ from procrastinate import jobs
         (None, None),
     ],
 )
-def test_job_get_context(scheduled_at, context_scheduled_at):
+def test_job_get_context(job_factory, scheduled_at, context_scheduled_at):
 
-    job = jobs.Job(
+    job = job_factory(
         id=12,
         queue="marsupilami",
         lock="sher",
@@ -35,6 +35,25 @@ def test_job_get_context(scheduled_at, context_scheduled_at):
         "attempts": 42,
         "call_string": "mytask[12](a='b')",
     }
+
+
+def test_job_evolve(job_factory):
+
+    job = job_factory(
+        id=12,
+        task_name="mytask",
+        lock="sher",
+        queue="marsupilami",
+    )
+
+    expected = job_factory(
+        id=13,
+        task_name="mytask",
+        lock="bu",
+        queue="marsupilami",
+    )
+
+    assert job.evolve(id=13, lock="bu") == expected
 
 
 def test_job_deferrer_defer(job_store, connector):

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -44,35 +44,6 @@ def test_job_evolve(job_factory):
     assert job.evolve(id=13, lock="bu") == expected
 
 
-def test_job_deferrer_defer(job_factory, job_store, connector):
-
-    job = job_factory(
-        queue="marsupilami",
-        lock="sher",
-        queueing_lock="houba",
-        task_name="mytask",
-        task_kwargs={"a": "b"},
-    )
-
-    id = jobs.JobDeferrer(job=job, job_store=job_store).defer(c=3)
-
-    assert id == 1
-
-    assert connector.jobs == {
-        1: {
-            "args": {"a": "b", "c": 3},
-            "attempts": 0,
-            "id": 1,
-            "lock": "sher",
-            "queueing_lock": "houba",
-            "queue_name": "marsupilami",
-            "scheduled_at": None,
-            "status": "todo",
-            "task_name": "mytask",
-        }
-    }
-
-
 @pytest.mark.asyncio
 async def test_job_deferrer_defer_async(job_factory, job_store, connector):
 
@@ -106,9 +77,7 @@ async def test_job_deferrer_defer_async(job_factory, job_store, connector):
 
 def test_job_scheduled_at_naive(job_factory):
     with pytest.raises(ValueError):
-        job_factory(
-            scheduled_at=pendulum.naive(2000, 1, 1),
-        )
+        job_factory(scheduled_at=pendulum.naive(2000, 1, 1),)
 
 
 def test_call_string(job_factory):

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -38,27 +38,15 @@ def test_job_get_context(job_factory, scheduled_at, context_scheduled_at):
 
 
 def test_job_evolve(job_factory):
-
-    job = job_factory(
-        id=12,
-        task_name="mytask",
-        lock="sher",
-        queue="marsupilami",
-    )
-
-    expected = job_factory(
-        id=13,
-        task_name="mytask",
-        lock="bu",
-        queue="marsupilami",
-    )
+    job = job_factory(id=12, task_name="mytask", lock="sher", queue="marsupilami")
+    expected = job_factory(id=13, task_name="mytask", lock="bu", queue="marsupilami")
 
     assert job.evolve(id=13, lock="bu") == expected
 
 
-def test_job_deferrer_defer(job_store, connector):
+def test_job_deferrer_defer(job_factory, job_store, connector):
 
-    job = jobs.Job(
+    job = job_factory(
         queue="marsupilami",
         lock="sher",
         queueing_lock="houba",
@@ -86,9 +74,9 @@ def test_job_deferrer_defer(job_store, connector):
 
 
 @pytest.mark.asyncio
-async def test_job_deferrer_defer_async(job_store, connector):
+async def test_job_deferrer_defer_async(job_factory, job_store, connector):
 
-    job = jobs.Job(
+    job = job_factory(
         queue="marsupilami",
         lock="sher",
         queueing_lock="houba",
@@ -116,15 +104,9 @@ async def test_job_deferrer_defer_async(job_store, connector):
     }
 
 
-def test_job_scheduled_at_naive():
+def test_job_scheduled_at_naive(job_factory):
     with pytest.raises(ValueError):
-        jobs.Job(
-            id=12,
-            queue="marsupilami",
-            lock="sher",
-            queueing_lock="houba",
-            task_name="mytask",
-            task_kwargs={"a": "b"},
+        job_factory(
             scheduled_at=pendulum.naive(2000, 1, 1),
         )
 


### PR DESCRIPTION
Improve job defer logs.

This is to avoid seeing this log at defer time:

```
INFO:procrastinate.jobs:Deferred job test[None]() with id: 1
```

And have this instead:

```
INFO:procrastinate.jobs:Deferred job test[1]()
```

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
