### PR TITLE
Make setup.py work against lightweight tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def ensure_version():
     # If running from the git repository
     try:
         version = (
-            subprocess.check_output(["git", "describe"])
+            subprocess.check_output(["git", "describe", "--tags"])
             .decode("utf-8")
             .strip()
             .replace("-", "+", 1)


### PR DESCRIPTION
Refs #175 

This is to make "deploy to pypi" work for lightweight release tags.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
