### PR TITLE
Create "set pool" lock lazily

### DIFF
--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -99,7 +99,7 @@ class AiopgConnector(connector.BaseConnector):
         self.json_dumps = json_dumps
         self.json_loads = json_loads
         self._pool_args = self._adapt_pool_args(kwargs, json_loads)
-        self._lock = asyncio.Lock()
+        self._lock: Optional[asyncio.Lock] = None
 
     @staticmethod
     def _adapt_pool_args(
@@ -165,6 +165,8 @@ class AiopgConnector(connector.BaseConnector):
     async def _get_pool(self) -> aiopg.Pool:
         if self._pool:
             return self._pool
+        if not self._lock:
+            self._lock = asyncio.Lock()
         async with self._lock:
             if not self._pool:
                 self.set_pool(await self._create_pool(self._pool_args))


### PR DESCRIPTION
Create the "set pool" lock lazily in `AiopgConnector`.

The `AiopgConnector` object is often created before the application has called `set_event_loop` or `set_event_loop_policy`. This means that no asyncio object should be created in `AiopgConnector` construction time.

In https://github.com/peopledoc/procrastinate/pull/202 we did a similar change for `Worker`, and the `asyncio.Event` object it uses.

PS: not sure what test we can add for that, knowing that we already have `test_execute_query_simultaneous`.

Closes #235 



<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
