### PR TITLE
Default log message contains task result

### DIFF
--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -225,20 +225,20 @@ class Worker:
 
         except Exception as e:
             task_result = None
-            log_title = "Job error"
+            log_title = "Error"
             log_action = "job_error"
             log_level = logging.ERROR
             exc_info = e
 
             retry_exception = task.get_retry_exception(exception=e, job=job)
             if retry_exception:
-                log_title = "Job error, to retry"
+                log_title = "Error, to retry"
                 log_action = "job_error_retry"
                 raise retry_exception from e
             raise exceptions.JobError() from e
 
         else:
-            log_title = "Job success"
+            log_title = "Success"
             log_action = "job_success"
             log_level = logging.INFO
             exc_info = False
@@ -255,7 +255,12 @@ class Worker:
 
             extra = context.log_extra(action=log_action)
 
-            text = f"{log_title} - Job {job.call_string} " f"in {duration:.3f} s"
+            text = (
+                f"Job {job.call_string} ended with status: {log_title}, "
+                f"lasted {duration:.3f} s"
+            )
+            if task_result:
+                text += f" - Result: {task_result}"[:250]
             self.logger.log(log_level, text, extra=extra, exc_info=exc_info)
 
     def stop(self):

--- a/procrastinate_demo/tasks.py
+++ b/procrastinate_demo/tasks.py
@@ -5,7 +5,7 @@ from procrastinate_demo.app import app
 
 @app.task(queue="sums")
 def sum(a, b):
-    print(a + b)
+    return a + b
 
 
 @app.task(queue="sleep")
@@ -17,7 +17,7 @@ async def sleep(i):
 
 @app.task(queue="sums")
 def sum_plus_one(a, b):
-    print(a + b + 1)
+    return a + b + 1
 
 
 @app.task(queue="retry", retry=100)

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -74,9 +74,11 @@ Try 2
     )
 
     assert stderr.count("Traceback (most recent call last)") == 3
-    assert stderr.count("Job error, to retry") == 2
-    waited_log = "Job error - Job tests.acceptance.app.multiple_exception_failures[6]()"
-    assert stderr.count(waited_log) == 1
+    assert stderr.count("status: Error, to retry") == 2
+    expected_log = "[6]() ended with status: Error"
+    assert stderr.count(expected_log) == 3
+    expected_log = "[6]() ended with status: Error, to retry"
+    assert stderr.count(expected_log) == 2
 
 
 def test_lock(defer, running_worker):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -161,6 +161,7 @@ async def test_run_job_log_result(caplog, app):
     assert len(records) == 1
     record = records[0]
     assert record.result == 12
+    assert "Result: 12" in record.message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes nothing
Tiny PR to scratch an itch: default log message of a success job now contains whatever the task returned (limited to 250 chars)

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?) < I'm doing a pass on the quickstart doc in parallel.
- [x] Had a good time contributing?
- [x] (Maintainers: add PR labels)
