### PR TITLE
Quickstart

### DIFF
--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -39,7 +39,7 @@ def set_verbosity(verbosity: int) -> None:
     level = get_log_level(verbosity=verbosity)
     logging.basicConfig(level=level)
     level_name = logging.getLevelName(level)
-    logger.info(
+    logger.debug(
         f"Log level set to {level_name}",
         extra={"action": "set_log_level", "value": level_name},
     )

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -43,6 +43,9 @@ class BaseConnector:
     ) -> None:
         raise exceptions.SyncConnectorConfigurationError
 
+    def __del__(self):
+        self.close()
+
 
 @utils.add_sync_api
 class BaseAsyncConnector(BaseConnector):

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -93,7 +93,7 @@ class Task:
 
     @property
     def full_path(self) -> str:
-        return f"{self.func.__module__}.{self.func.__name__}"
+        return utils.get_full_path(self.func)
 
     async def defer_async(self, **task_kwargs: types.JSONValue) -> int:
         """

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -47,7 +47,7 @@ def test_nominal(defer, worker):
     stdout, stderr = worker()
 
     assert stdout.splitlines() == ["Launching a worker on all queues", "12", "7", "4"]
-    assert stderr.startswith("INFO:procrastinate.")
+    assert stderr.startswith("DEBUG:procrastinate.")
 
     defer("product_task", a=5, b=4)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -183,3 +183,49 @@ def test_causes():
         result = list(utils.causes(exc2))
 
     assert result == [e1, e2, e3]
+
+
+def test_get_module_name_path1():
+    # Calling the function on itself
+    assert utils._get_module_name(utils._get_module_name) == "procrastinate.utils"
+
+
+def test_get_module_name_path2():
+    def yay():
+        pass
+
+    yay.__module__ = "__main__"
+    # We're probably doing strange things to the pytest binary
+    # but it's probably harmless
+    del sys.modules["__main__"].__file__
+
+    # Calling the function on itself
+    assert utils._get_module_name(yay) == "__main__"
+
+
+def test_get_module_name_path3():
+    def yay():
+        pass
+
+    yay.__module__ = "__main__"
+    sys.modules["__main__"].__file__ = "/home"
+
+    # Calling the function on itself
+    assert utils._get_module_name(yay) == "__main__"
+
+
+def test_get_module_name_path4():
+    def yay():
+        pass
+
+    yay.__module__ = "__main__"
+    sys.modules["__main__"].__file__ = "a/b.py"
+
+    # Calling the function on itself
+    assert utils._get_module_name(yay) == "a.b"
+
+
+def test_get_full_path():
+    path = "procrastinate.utils.get_full_path"
+    # Calling the function on itself
+    assert utils.get_full_path(utils.get_full_path) == path


### PR DESCRIPTION
Closes no ticket (again! sorry)

Fixed quickstart which had multiple slight problems:

- Rewrote the problematic parts of quickstart
- Close the connection when the connector is deleted
- Avoid having tasks named `__main__.*` even when they're declared in python files that are launched by `python that_file.py`

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
- [x] Had a good time contributing?
- [x] (Maintainers: add PR labels)
