### PR TITLE
Use python-dateutil to parse date

### DIFF
--- a/docs/howto/schedule.rst
+++ b/docs/howto/schedule.rst
@@ -20,10 +20,9 @@ Also, you can configure a delay from now::
 
     clean.configure(schedule_in={"hours": 1, "minutes": 30}).defer()
 
-The details on the parameters you can use are in the `pendulum documentation`_
-(because we use pendulum under the hood).
+The details on the parameters you can use are in the `python documentation`_.
 
-.. _`pendulum documentation`: https://pendulum.eustace.io/docs/#addition-and-subtraction
+.. _`python documentation`: https://docs.python.org/3/library/datetime.html#timedelta-objects
 
 From the command line
 ^^^^^^^^^^^^^^^^^^^^^

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -1,12 +1,12 @@
 import asyncio
 import contextlib
+import datetime
 import json
 import logging
 import os
 from typing import Any, Callable, Dict, Optional
 
 import click
-import pendulum
 
 import procrastinate
 from procrastinate import connector, exceptions, jobs, shell, types, utils, worker
@@ -283,20 +283,16 @@ def load_json_args(json_args: str, json_loads: Callable) -> types.JSONDict:
     return args
 
 
-# return type should not be Optional[str], but there's a typing bug in
-# Pendulum 2.1.0 (https://github.com/sdispater/pendulum/issues/450)
-def get_schedule_at(at: Optional[str]) -> Optional[pendulum.DateTime]:
+def get_schedule_at(at: Optional[str]) -> Optional[datetime.datetime]:
     if at is None:
         return None
 
     try:
-        datetime = pendulum.parse(at)
-        if not isinstance(datetime, pendulum.DateTime):
-            raise ValueError
-    except (pendulum.exceptions.ParserError, ValueError):
+        dt = utils.parse_datetime(at)
+    except (ValueError):
         raise click.BadOptionUsage("--at", f"Cannot parse datetime {at}")
 
-    return datetime
+    return dt
 
 
 def get_schedule_in(in_: Optional[int]) -> Optional[Dict[str, int]]:

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -289,7 +289,7 @@ def get_schedule_at(at: Optional[str]) -> Optional[datetime.datetime]:
 
     try:
         dt = utils.parse_datetime(at)
-    except (ValueError):
+    except ValueError:
         raise click.BadOptionUsage("--at", f"Cannot parse datetime {at}")
 
     return dt

--- a/procrastinate/retry.py
+++ b/procrastinate/retry.py
@@ -2,13 +2,14 @@
 A retry strategy class lets procrastinate know what to do when a job fails: should it
 try again? And when?
 """
+import datetime
 
 from typing import Iterable, Optional, Type, Union
 
 import attr
-import pendulum
 
 from procrastinate import exceptions
+from procrastinate import utils
 
 
 class BaseRetryStrategy:
@@ -24,8 +25,8 @@ class BaseRetryStrategy:
         if schedule_in is None:
             return None
 
-        schedule_at = pendulum.now("UTC").add(seconds=schedule_in)
-        return exceptions.JobRetry(schedule_at)
+        schedule_at = utils.utcnow() + datetime.timedelta(seconds=schedule_in)
+        return exceptions.JobRetry(schedule_at.replace(microsecond=0))
 
     def get_schedule_in(self, *, exception: Exception, attempts: int) -> Optional[int]:
         """

--- a/procrastinate/retry.py
+++ b/procrastinate/retry.py
@@ -3,13 +3,11 @@ A retry strategy class lets procrastinate know what to do when a job fails: shou
 try again? And when?
 """
 import datetime
-
 from typing import Iterable, Optional, Type, Union
 
 import attr
 
-from procrastinate import exceptions
-from procrastinate import utils
+from procrastinate import exceptions, utils
 
 
 class BaseRetryStrategy:

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -146,8 +146,8 @@ class Task:
             schedule_in)
         schedule_in :
             A dict describing the time interval before the task should be launched.
-            See details in the `pendulum documentation
-            <https://pendulum.eustace.io/docs/#addition-and-subtraction>`__
+            See details in the `python documentation
+            <https://docs.python.org/3/library/datetime.html#timedelta-objects>`__
             (incompatible with schedule_at)
 
         queue :

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -2,8 +2,6 @@ import datetime
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
-import pendulum
-
 from procrastinate import app, exceptions, jobs
 from procrastinate import retry as retry_module
 from procrastinate import store, types, utils
@@ -35,7 +33,7 @@ def configure_task(
         raise ValueError("Cannot set both schedule_at and schedule_in")
 
     if schedule_in is not None:
-        schedule_at = pendulum.now("UTC").add(**schedule_in)
+        schedule_at = utils.utcnow() + datetime.timedelta(**schedule_in)
 
     task_kwargs = task_kwargs or {}
     return jobs.JobDeferrer(

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -239,7 +239,7 @@ def task_context(awaitable: Awaitable, name: str):
 
 
 def utcnow() -> datetime.datetime:
-    return datetime.datetime.now(datetime.timezone.utc)
+    return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 def aware_datetime(

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -242,26 +242,6 @@ def utcnow() -> datetime.datetime:
     return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
-def aware_datetime(
-    year: int,
-    month: int,
-    day: int,
-    hour: int = 0,
-    minute: int = 0,
-    second: int = 0,
-    microsecond: int = 0,
-    tz_offset: Optional[int] = None,
-) -> datetime.datetime:
-    tzinfo = (
-        datetime.timezone(datetime.timedelta(hours=tz_offset))
-        if tz_offset
-        else datetime.timezone.utc
-    )
-    return datetime.datetime(
-        year, month, day, hour, minute, second, microsecond, tzinfo=tzinfo
-    )
-
-
 def parse_datetime(raw: str) -> datetime.datetime:
     try:
         # this parser is the stricter one, so we try it first

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -242,13 +242,24 @@ def utcnow() -> datetime.datetime:
     return datetime.datetime.now(datetime.timezone.utc)
 
 
-def aware_datetime(*args, tz_offset: Optional[int] = None) -> datetime.datetime:
+def aware_datetime(
+    year: int,
+    month: int,
+    day: int,
+    hour: int = 0,
+    minute: int = 0,
+    second: int = 0,
+    microsecond: int = 0,
+    tz_offset: Optional[int] = None,
+) -> datetime.datetime:
     tzinfo = (
         datetime.timezone(datetime.timedelta(hours=tz_offset))
         if tz_offset
         else datetime.timezone.utc
     )
-    return datetime.datetime(*args, tzinfo=tzinfo)
+    return datetime.datetime(
+        year, month, day, hour, minute, second, microsecond, tzinfo=tzinfo
+    )
 
 
 def parse_datetime(raw: str) -> datetime.datetime:

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -245,9 +245,14 @@ def utcnow() -> datetime.datetime:
 def parse_datetime(raw: str) -> datetime.datetime:
     try:
         # this parser is the stricter one, so we try it first
-        return dateutil.parser.isoparse(raw)
+        dt = dateutil.parser.isoparse(raw)
+        if not dt.tzinfo:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt
     except ValueError:
         pass
     # this parser is quite forgiving, and will attempt to return
     # a value in most circumstances, so we use it as last option
-    return dateutil.parser.parse(raw)
+    dt = dateutil.parser.parse(raw)
+    dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt

--- a/procrastinate/utils.py
+++ b/procrastinate/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import datetime
 import functools
 import importlib
 import inspect
@@ -7,6 +8,8 @@ import logging
 import pathlib
 import types
 from typing import Any, Awaitable, Iterable, Optional, Type, TypeVar
+
+import dateutil.parser
 
 from procrastinate import exceptions
 
@@ -233,3 +236,27 @@ def task_context(awaitable: Awaitable, name: str):
         yield task
     finally:
         task.cancel()
+
+
+def utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def aware_datetime(*args, tz_offset: Optional[int] = None) -> datetime.datetime:
+    tzinfo = (
+        datetime.timezone(datetime.timedelta(hours=tz_offset))
+        if tz_offset
+        else datetime.timezone.utc
+    )
+    return datetime.datetime(*args, tzinfo=tzinfo)
+
+
+def parse_datetime(raw: str) -> datetime.datetime:
+    try:
+        # this parser is the stricter one, so we try it first
+        return dateutil.parser.isoparse(raw)
+    except ValueError:
+        pass
+    # this parser is quite forgiving, and will attempt to return
+    # a value in most circumstances, so we use it as last option
+    return dateutil.parser.parse(raw)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     attrs
     click
     croniter
-    pendulum
+    python-dateutil
     psycopg2-binary  # This is a dependency of aiopg anyway
     typing-extensions
     # Backport from Python 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ testpaths =
 [mypy]
 no_implicit_optional = True
 
-[mypy-setuptools.*,psycopg2.*,pendulum.*,importlib_metadata.*,importlib_resources.*,aiopg.*,croniter.*]
+[mypy-setuptools.*,psycopg2.*,importlib_metadata.*,importlib_resources.*,aiopg.*,croniter.*]
 ignore_missing_imports = True
 
 [coverage:report]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,15 +172,9 @@ def job_factory(serial, random_str):
 
     return factory
 
+
 def aware_datetime(
-    year,
-    month,
-    day,
-    hour=0,
-    minute=0,
-    second=0,
-    microsecond=0,
-    tz_offset=None,
+    year, month, day, hour=0, minute=0, second=0, microsecond=0, tz_offset=None,
 ):
     tzinfo = (
         datetime.timezone(datetime.timedelta(hours=tz_offset))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import functools
 import itertools
 import os
@@ -170,3 +171,22 @@ def job_factory(serial, random_str):
         return jobs.Job(**final_kwargs)
 
     return factory
+
+def aware_datetime(
+    year,
+    month,
+    day,
+    hour=0,
+    minute=0,
+    second=0,
+    microsecond=0,
+    tz_offset=None,
+):
+    tzinfo = (
+        datetime.timezone(datetime.timedelta(hours=tz_offset))
+        if tz_offset
+        else datetime.timezone.utc
+    )
+    return datetime.datetime(
+        year, month, day, hour, minute, second, microsecond, tzinfo=tzinfo
+    )

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -1,10 +1,9 @@
 import datetime
 
-import pendulum
 import psycopg2.errors
 import pytest
 
-from procrastinate import exceptions, jobs, store
+from procrastinate import exceptions, jobs, store, utils
 
 pytestmark = pytest.mark.asyncio
 
@@ -28,7 +27,7 @@ def get_all(aiopg_connector):
     "job_kwargs",
     [
         {"queue": "queue_a"},
-        {"queue": "queue_a", "scheduled_at": pendulum.datetime(2000, 1, 1)},
+        {"queue": "queue_a", "scheduled_at": utils.aware_datetime(2000, 1, 1)},
     ],
 )
 async def test_fetch_job(pg_job_store, job_factory, job_kwargs):
@@ -51,7 +50,7 @@ async def test_fetch_job(pg_job_store, job_factory, job_kwargs):
         # We won't see this one because of the queue
         {"queue": "queue_b"},
         # We won't see this one because of the scheduled date
-        {"queue": "queue_a", "scheduled_at": pendulum.datetime(2100, 1, 1)},
+        {"queue": "queue_a", "scheduled_at": utils.aware_datetime(2100, 1, 1)},
     ],
 )
 async def test_get_job_no_result(pg_job_store, job_factory, job_kwargs):

--- a/tests/integration/test_store.py
+++ b/tests/integration/test_store.py
@@ -3,7 +3,9 @@ import datetime
 import psycopg2.errors
 import pytest
 
-from procrastinate import exceptions, jobs, store, utils
+from procrastinate import exceptions, jobs, store
+
+from .. import conftest
 
 pytestmark = pytest.mark.asyncio
 
@@ -27,7 +29,7 @@ def get_all(aiopg_connector):
     "job_kwargs",
     [
         {"queue": "queue_a"},
-        {"queue": "queue_a", "scheduled_at": utils.aware_datetime(2000, 1, 1)},
+        {"queue": "queue_a", "scheduled_at": conftest.aware_datetime(2000, 1, 1)},
     ],
 )
 async def test_fetch_job(pg_job_store, job_factory, job_kwargs):
@@ -50,7 +52,7 @@ async def test_fetch_job(pg_job_store, job_factory, job_kwargs):
         # We won't see this one because of the queue
         {"queue": "queue_b"},
         # We won't see this one because of the scheduled date
-        {"queue": "queue_a", "scheduled_at": utils.aware_datetime(2100, 1, 1)},
+        {"queue": "queue_a", "scheduled_at": conftest.aware_datetime(2100, 1, 1)},
     ],
 )
 async def test_get_job_no_result(pg_job_store, job_factory, job_kwargs):

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,10 +1,9 @@
 import asyncio
 
-import pendulum
 import pytest
 
 from procrastinate import app as app_module
-from procrastinate import tasks
+from procrastinate import tasks, utils
 
 
 def task_func():
@@ -107,7 +106,7 @@ def test_from_path(mocker):
 
 
 def test_app_configure_task(app):
-    scheduled_at = pendulum.datetime(2000, 1, 1)
+    scheduled_at = utils.aware_datetime(2000, 1, 1)
     job = app.configure_task(
         name="my_name",
         queue="marsupilami",

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -3,7 +3,9 @@ import asyncio
 import pytest
 
 from procrastinate import app as app_module
-from procrastinate import tasks, utils
+from procrastinate import tasks
+
+from .. import conftest
 
 
 def task_func():
@@ -106,7 +108,7 @@ def test_from_path(mocker):
 
 
 def test_app_configure_task(app):
-    scheduled_at = utils.aware_datetime(2000, 1, 1)
+    scheduled_at = conftest.aware_datetime(2000, 1, 1)
     job = app.configure_task(
         name="my_name",
         queue="marsupilami",

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,13 +1,15 @@
-import pendulum
+import datetime
+
 import pytest
 
 from procrastinate import jobs
+from procrastinate import utils
 
 
 @pytest.mark.parametrize(
     "scheduled_at,context_scheduled_at",
     [
-        (pendulum.datetime(2000, 1, 1, tz="Europe/Paris"), "2000-01-01T00:00:00+01:00"),
+        (utils.aware_datetime(2000, 1, 1, tz_offset=1), "2000-01-01T00:00:00+01:00"),
         (None, None),
     ],
 )
@@ -77,7 +79,7 @@ async def test_job_deferrer_defer_async(job_factory, job_store, connector):
 
 def test_job_scheduled_at_naive(job_factory):
     with pytest.raises(ValueError):
-        job_factory(scheduled_at=pendulum.naive(2000, 1, 1),)
+        job_factory(scheduled_at=datetime.datetime(2000, 1, 1))
 
 
 def test_call_string(job_factory):

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2,13 +2,15 @@ import datetime
 
 import pytest
 
-from procrastinate import jobs, utils
+from procrastinate import jobs
+
+from .. import conftest
 
 
 @pytest.mark.parametrize(
     "scheduled_at,context_scheduled_at",
     [
-        (utils.aware_datetime(2000, 1, 1, tz_offset=1), "2000-01-01T00:00:00+01:00"),
+        (conftest.aware_datetime(2000, 1, 1, tz_offset=1), "2000-01-01T00:00:00+01:00"),
         (None, None),
     ],
 )

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2,8 +2,7 @@ import datetime
 
 import pytest
 
-from procrastinate import jobs
-from procrastinate import utils
+from procrastinate import jobs, utils
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,8 +1,10 @@
-import pendulum
+import datetime
+
 import pytest
 
 from procrastinate import exceptions
 from procrastinate import retry as retry_module
+from procrastinate import utils
 
 
 @pytest.mark.parametrize(
@@ -70,9 +72,9 @@ def test_get_retry_exception_returns_none():
 def test_get_retry_exception_returns():
     strategy = retry_module.RetryStrategy(max_attempts=10, wait=5.0)
 
-    now = pendulum.datetime(2000, 1, 1, tz="UTC")
-    expected = pendulum.datetime(2000, 1, 1, 0, 0, 5, tz="UTC")
-    with pendulum.test(now):
-        exc = strategy.get_retry_exception(exception=None, attempts=1)
-        assert isinstance(exc, exceptions.JobRetry)
-        assert exc.scheduled_at == expected
+    now = utils.utcnow()
+    expected = now + datetime.timedelta(seconds=5, microseconds=0)
+
+    exc = strategy.get_retry_exception(exception=None, attempts=1)
+    assert isinstance(exc, exceptions.JobRetry)
+    assert exc.scheduled_at == expected.replace(microsecond=0)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -2,7 +2,9 @@ import uuid
 
 import pytest
 
-from procrastinate import exceptions, jobs, utils
+from procrastinate import exceptions, jobs
+
+from .. import conftest
 
 pytestmark = pytest.mark.asyncio
 
@@ -92,7 +94,7 @@ async def test_get_stalled_jobs_stalled(job_store, job_factory, connector):
     job = job_factory(id=1)
     await job_store.defer_job_async(job=job)
     await job_store.fetch_job(queues=None)
-    connector.events[1][-1]["at"] = utils.aware_datetime(2000, 1, 1)
+    connector.events[1][-1]["at"] = conftest.aware_datetime(2000, 1, 1)
     assert await job_store.get_stalled_jobs(nb_seconds=1000) == [job]
 
 
@@ -118,7 +120,7 @@ async def test_delete_old_jobs(
 async def test_finish_job(job_store, job_factory, connector):
     job = job_factory(id=1)
     await job_store.defer_job_async(job=job)
-    retry_at = utils.aware_datetime(2000, 1, 1)
+    retry_at = conftest.aware_datetime(2000, 1, 1)
 
     await job_store.finish_job(job=job, status=jobs.Status.TODO, scheduled_at=retry_at)
     assert connector.queries[-1] == (

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1,9 +1,8 @@
 import uuid
 
-import pendulum
 import pytest
 
-from procrastinate import exceptions, jobs
+from procrastinate import exceptions, jobs, utils
 
 pytestmark = pytest.mark.asyncio
 
@@ -93,7 +92,7 @@ async def test_get_stalled_jobs_stalled(job_store, job_factory, connector):
     job = job_factory(id=1)
     await job_store.defer_job_async(job=job)
     await job_store.fetch_job(queues=None)
-    connector.events[1][-1]["at"] = pendulum.datetime(2000, 1, 1)
+    connector.events[1][-1]["at"] = utils.aware_datetime(2000, 1, 1)
     assert await job_store.get_stalled_jobs(nb_seconds=1000) == [job]
 
 
@@ -119,7 +118,7 @@ async def test_delete_old_jobs(
 async def test_finish_job(job_store, job_factory, connector):
     job = job_factory(id=1)
     await job_store.defer_job_async(job=job)
-    retry_at = pendulum.datetime(2000, 1, 1)
+    retry_at = utils.aware_datetime(2000, 1, 1)
 
     await job_store.finish_job(job=job, status=jobs.Status.TODO, scheduled_at=retry_at)
     assert connector.queries[-1] == (

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,7 +1,6 @@
-import pendulum
 import pytest
 
-from procrastinate import exceptions, tasks
+from procrastinate import exceptions, tasks, utils
 
 
 def task_func():
@@ -51,20 +50,20 @@ def test_configure_task_schedule_at(job_store):
     job = tasks.configure_task(
         name="my_name",
         job_store=job_store,
-        schedule_at=pendulum.datetime(2000, 1, 1, tz="Europe/Paris"),
+        schedule_at=utils.aware_datetime(2000, 1, 1, tz_offset=1),
     ).job
 
-    assert job.scheduled_at == pendulum.datetime(2000, 1, 1, tz="Europe/Paris")
+    assert job.scheduled_at == utils.aware_datetime(2000, 1, 1, tz_offset=1)
 
 
-def test_configure_task_schedule_in(job_store):
-    now = pendulum.datetime(2000, 1, 1, tz="Europe/Paris")
-    with pendulum.test(now):
-        job = tasks.configure_task(
-            name="my_name", job_store=job_store, schedule_in={"hours": 2}
-        ).job
+def test_configure_task_schedule_in(job_store, mocker):
+    now = utils.aware_datetime(2000, 1, 1, tz_offset=1)
+    mocker.patch.object(utils, "utcnow", return_value=now)
+    job = tasks.configure_task(
+        name="my_name", job_store=job_store, schedule_in={"hours": 2}
+    ).job
 
-    assert job.scheduled_at == pendulum.datetime(2000, 1, 1, 2, tz="Europe/Paris")
+    assert job.scheduled_at == utils.aware_datetime(2000, 1, 1, 2, tz_offset=1)
 
 
 def test_configure_task_schedule_in_and_schedule_at(job_store):
@@ -72,7 +71,7 @@ def test_configure_task_schedule_in_and_schedule_at(job_store):
         tasks.configure_task(
             name="my_name",
             job_store=job_store,
-            schedule_at=pendulum.datetime(2000, 1, 1, tz="Europe/Paris"),
+            schedule_at=utils.aware_datetime(2000, 1, 1, tz_offset=1),
             schedule_in={"hours": 2},
         )
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -2,6 +2,8 @@ import pytest
 
 from procrastinate import exceptions, tasks, utils
 
+from .. import conftest
+
 
 def task_func():
     pass
@@ -50,20 +52,20 @@ def test_configure_task_schedule_at(job_store):
     job = tasks.configure_task(
         name="my_name",
         job_store=job_store,
-        schedule_at=utils.aware_datetime(2000, 1, 1, tz_offset=1),
+        schedule_at=conftest.aware_datetime(2000, 1, 1, tz_offset=1),
     ).job
 
-    assert job.scheduled_at == utils.aware_datetime(2000, 1, 1, tz_offset=1)
+    assert job.scheduled_at == conftest.aware_datetime(2000, 1, 1, tz_offset=1)
 
 
 def test_configure_task_schedule_in(job_store, mocker):
-    now = utils.aware_datetime(2000, 1, 1, tz_offset=1)
+    now = conftest.aware_datetime(2000, 1, 1, tz_offset=1)
     mocker.patch.object(utils, "utcnow", return_value=now)
     job = tasks.configure_task(
         name="my_name", job_store=job_store, schedule_in={"hours": 2}
     ).job
 
-    assert job.scheduled_at == utils.aware_datetime(2000, 1, 1, 2, tz_offset=1)
+    assert job.scheduled_at == conftest.aware_datetime(2000, 1, 1, 2, tz_offset=1)
 
 
 def test_configure_task_schedule_in_and_schedule_at(job_store):
@@ -71,7 +73,7 @@ def test_configure_task_schedule_in_and_schedule_at(job_store):
         tasks.configure_task(
             name="my_name",
             job_store=job_store,
-            schedule_at=utils.aware_datetime(2000, 1, 1, tz_offset=1),
+            schedule_at=conftest.aware_datetime(2000, 1, 1, tz_offset=1),
             schedule_in={"hours": 2},
         )
 

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -1,7 +1,8 @@
 import asyncio
 
-import pendulum
 import pytest
+
+from procrastinate import utils
 
 
 def test_reset(connector):
@@ -145,12 +146,12 @@ def test_select_stalled_jobs_all(connector):
         },
     }
     connector.events = {
-        1: [{"at": pendulum.datetime(2000, 1, 1)}],
-        2: [{"at": pendulum.datetime(2000, 1, 1)}],
-        3: [{"at": pendulum.datetime(2000, 1, 1)}],
-        4: [{"at": pendulum.datetime(2100, 1, 1)}],
-        5: [{"at": pendulum.datetime(2000, 1, 1)}],
-        6: [{"at": pendulum.datetime(2000, 1, 1)}],
+        1: [{"at": utils.aware_datetime(2000, 1, 1)}],
+        2: [{"at": utils.aware_datetime(2000, 1, 1)}],
+        3: [{"at": utils.aware_datetime(2000, 1, 1)}],
+        4: [{"at": utils.aware_datetime(2100, 1, 1)}],
+        5: [{"at": utils.aware_datetime(2000, 1, 1)}],
+        6: [{"at": utils.aware_datetime(2000, 1, 1)}],
     }
 
     results = connector.select_stalled_jobs_all(
@@ -171,10 +172,10 @@ def test_delete_old_jobs_run(connector):
         4: {"id": 4, "status": "succeeded", "queue_name": "marsupilami"},
     }
     connector.events = {
-        1: [{"type": "succeeded", "at": pendulum.datetime(2000, 1, 1)}],
-        2: [{"type": "succeeded", "at": pendulum.datetime(2000, 1, 1)}],
-        3: [{"type": "succeeded", "at": pendulum.now()}],
-        4: [{"type": "succeeded", "at": pendulum.datetime(2000, 1, 1)}],
+        1: [{"type": "succeeded", "at": utils.aware_datetime(2000, 1, 1)}],
+        2: [{"type": "succeeded", "at": utils.aware_datetime(2000, 1, 1)}],
+        3: [{"type": "succeeded", "at": utils.utcnow()}],
+        4: [{"type": "succeeded", "at": utils.aware_datetime(2000, 1, 1)}],
     }
 
     connector.delete_old_jobs_run(
@@ -208,7 +209,7 @@ def test_fetch_job_one(connector):
         task_name="mytask",
         args={},
         queue="marsupilami",
-        scheduled_at=pendulum.datetime(2100, 1, 1),
+        scheduled_at=utils.aware_datetime(2100, 1, 1),
         lock="c",
         queueing_lock="c",
     )
@@ -266,7 +267,7 @@ def test_finish_job_run_retry(connector):
     job_row = connector.fetch_job_one(queues=None)
     id = job_row["id"]
 
-    retry_at = pendulum.datetime(2000, 1, 1)
+    retry_at = utils.aware_datetime(2000, 1, 1)
     connector.finish_job_run(job_id=id, status="todo", scheduled_at=retry_at)
 
     assert connector.jobs[id]["attempts"] == 1

--- a/tests/unit/test_testing.py
+++ b/tests/unit/test_testing.py
@@ -4,6 +4,8 @@ import pytest
 
 from procrastinate import utils
 
+from .. import conftest
+
 
 def test_reset(connector):
     connector.jobs = {1: {}}
@@ -146,12 +148,12 @@ def test_select_stalled_jobs_all(connector):
         },
     }
     connector.events = {
-        1: [{"at": utils.aware_datetime(2000, 1, 1)}],
-        2: [{"at": utils.aware_datetime(2000, 1, 1)}],
-        3: [{"at": utils.aware_datetime(2000, 1, 1)}],
-        4: [{"at": utils.aware_datetime(2100, 1, 1)}],
-        5: [{"at": utils.aware_datetime(2000, 1, 1)}],
-        6: [{"at": utils.aware_datetime(2000, 1, 1)}],
+        1: [{"at": conftest.aware_datetime(2000, 1, 1)}],
+        2: [{"at": conftest.aware_datetime(2000, 1, 1)}],
+        3: [{"at": conftest.aware_datetime(2000, 1, 1)}],
+        4: [{"at": conftest.aware_datetime(2100, 1, 1)}],
+        5: [{"at": conftest.aware_datetime(2000, 1, 1)}],
+        6: [{"at": conftest.aware_datetime(2000, 1, 1)}],
     }
 
     results = connector.select_stalled_jobs_all(
@@ -172,10 +174,10 @@ def test_delete_old_jobs_run(connector):
         4: {"id": 4, "status": "succeeded", "queue_name": "marsupilami"},
     }
     connector.events = {
-        1: [{"type": "succeeded", "at": utils.aware_datetime(2000, 1, 1)}],
-        2: [{"type": "succeeded", "at": utils.aware_datetime(2000, 1, 1)}],
+        1: [{"type": "succeeded", "at": conftest.aware_datetime(2000, 1, 1)}],
+        2: [{"type": "succeeded", "at": conftest.aware_datetime(2000, 1, 1)}],
         3: [{"type": "succeeded", "at": utils.utcnow()}],
-        4: [{"type": "succeeded", "at": utils.aware_datetime(2000, 1, 1)}],
+        4: [{"type": "succeeded", "at": conftest.aware_datetime(2000, 1, 1)}],
     }
 
     connector.delete_old_jobs_run(
@@ -209,7 +211,7 @@ def test_fetch_job_one(connector):
         task_name="mytask",
         args={},
         queue="marsupilami",
-        scheduled_at=utils.aware_datetime(2100, 1, 1),
+        scheduled_at=conftest.aware_datetime(2100, 1, 1),
         lock="c",
         queueing_lock="c",
     )
@@ -267,7 +269,7 @@ def test_finish_job_run_retry(connector):
     job_row = connector.fetch_job_one(queues=None)
     id = job_row["id"]
 
-    retry_at = utils.aware_datetime(2000, 1, 1)
+    retry_at = conftest.aware_datetime(2000, 1, 1)
     connector.finish_job_run(job_id=id, status="todo", scheduled_at=retry_at)
 
     assert connector.jobs[id]["attempts"] == 1

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -286,7 +286,7 @@ async def test_task_context_exception(caplog):
 def test_utcnow(mocker):
     dt = mocker.patch("datetime.datetime")
     assert utils.utcnow() == dt.now.return_value
-    dt.now.assert_called_once_with(datetime.timezone.utc)
+    dt.now.assert_called_once_with(tz=datetime.timezone.utc)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -289,7 +289,6 @@ def test_utcnow(mocker):
     dt.now.assert_called_once_with(tz=datetime.timezone.utc)
 
 
-
 @pytest.mark.parametrize(
     "input, expected",
     [

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,8 @@
 import asyncio
+import datetime
 import sys
 import types
 
-import datetime
 import pytest
 
 from procrastinate import exceptions, utils

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -289,36 +289,43 @@ def test_utcnow(mocker):
     dt.now.assert_called_once_with(tz=datetime.timezone.utc)
 
 
-@pytest.mark.parametrize(
-    "offset, expected",
-    [
-        (None, datetime.datetime(2020, 1, 5, 0, 0, tzinfo=datetime.timezone.utc)),
-        (
-            2,
-            datetime.datetime(
-                2020, 1, 5, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=2))
-            ),
-        ),
-        (
-            -4,
-            datetime.datetime(
-                2020, 1, 5, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-4))
-            ),
-        ),
-    ],
-)
-def test_aware_datetime(offset, expected):
-    assert utils.aware_datetime(2020, 1, 5, 0, 0, tz_offset=offset) == expected
-
 
 @pytest.mark.parametrize(
     "input, expected",
     [
-        ("2020-01-05", datetime.datetime(2020, 1, 5, 0, 0)),
+        (
+            "2020-01-05",
+            datetime.datetime(2020, 1, 5, 0, 0, tzinfo=datetime.timezone.utc),
+        ),
+        (
+            "2020/01/05",
+            datetime.datetime(2020, 1, 5, 0, 0, tzinfo=datetime.timezone.utc),
+        ),
+        (
+            "2020/01/05 22:07",
+            datetime.datetime(2020, 1, 5, 22, 7, tzinfo=datetime.timezone.utc),
+        ),
+        (
+            "1984-06-02 19:05:57",
+            datetime.datetime(1984, 6, 2, 19, 5, 57, tzinfo=datetime.timezone.utc),
+        ),
         (
             "1984-06-02T19:05:57.720Z",
             datetime.datetime(
                 1984, 6, 2, 19, 5, 57, 720000, tzinfo=datetime.timezone.utc
+            ),
+        ),
+        (
+            "1984-06-02T19:05:57.720+01:00",
+            datetime.datetime(
+                1984,
+                6,
+                2,
+                19,
+                5,
+                57,
+                720000,
+                tzinfo=datetime.timezone(datetime.timedelta(hours=1)),
             ),
         ),
     ],

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,10 +1,9 @@
 import asyncio
 import logging
 
-import pendulum
 import pytest
 
-from procrastinate import exceptions, job_context, jobs, tasks, worker
+from procrastinate import exceptions, job_context, jobs, tasks, utils, worker
 
 pytestmark = pytest.mark.asyncio
 
@@ -75,7 +74,7 @@ async def test_process_job_retry_failed_job(
     async def coro(*args, **kwargs):
         pass
 
-    scheduled_at = pendulum.datetime(2000, 1, 1, tz="UTC")
+    scheduled_at = utils.aware_datetime(2000, 1, 1)
     test_worker.run_job = mocker.Mock(
         side_effect=exceptions.JobRetry(scheduled_at=scheduled_at)
     )

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -3,7 +3,9 @@ import logging
 
 import pytest
 
-from procrastinate import exceptions, job_context, jobs, tasks, utils, worker
+from procrastinate import exceptions, job_context, jobs, tasks, worker
+
+from .. import conftest
 
 pytestmark = pytest.mark.asyncio
 
@@ -74,7 +76,7 @@ async def test_process_job_retry_failed_job(
     async def coro(*args, **kwargs):
         pass
 
-    scheduled_at = utils.aware_datetime(2000, 1, 1)
+    scheduled_at = conftest.aware_datetime(2000, 1, 1)
     test_worker.run_job = mocker.Mock(
         side_effect=exceptions.JobRetry(scheduled_at=scheduled_at)
     )


### PR DESCRIPTION

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
- [x] Documentation
- [x] Had a good time contributing?
- [ ] (Maintainers: add PR labels)

## Rationale

`procrastinate` currently relies on `pendulum` to manipulate and parse dates, which is sometimes difficult to install (see https://github.com/sdispater/pendulum/issues/457 for instance).

As the needs of `procrastinate` in terms of date parsing and manipulation are quite light, and `python-dateutil` is already an indirect dependency of `procrastinate` (not sure which dependency relies on it though), I think it makes sense to replace `pendulum` with a couple of functions and calls to `python-dateutil`.

This PR does exactly that, and as far as I can tell coverage remains stable and tests are passing.

Let me know what you think about it :)