### PR TITLE
Fix quickstart documentation

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -175,6 +175,7 @@ Your final file
 ::
 
     import random
+    import time
     import sys
 
     from procrastinate import App, AiopgConnector
@@ -183,7 +184,7 @@ Your final file
 
     @app.task
     def sum(a, b):
-        sleep(random.random() * 5)  # Sleep up to 5 seconds
+        time.sleep(random.random() * 5)  # Sleep up to 5 seconds
         return a + b
 
     if __name__ == "__main__":


### PR DESCRIPTION
Closes #<ticket number>

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
- [x] Had a good time contributing?
- [ ] (Maintainers: add PR labels)

Just fixing something I noticed while doing the quickstart today. The time import that is present in the earlier steps is omitted in the "Your final file" section.
