### PR TITLE
Fix the "every second periodic task" bug

### DIFF
--- a/procrastinate/periodic.py
+++ b/procrastinate/periodic.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 import logging
 import time
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 import attr
 import croniter
@@ -64,8 +64,9 @@ class PeriodicDeferrer:
             return
 
         while True:
-            await self.defer_jobs(jobs_to_defer=self.get_previous_tasks())
-            await self.wait(next_tick=self.get_next_tick())
+            now = time.time()
+            await self.defer_jobs(jobs_to_defer=self.get_previous_tasks(now=now))
+            await self.wait(next_tick=self.get_next_tick(now=now))
 
     # Internal methods
 
@@ -82,28 +83,25 @@ class PeriodicDeferrer:
         self.periodic_tasks.append(periodic_task)
         return periodic_task
 
-    def get_next_tick(self, now: Optional[float] = None):
+    def get_next_tick(self, now: float):
         """
         Return the number of seconds to wait before the next periodic task needs to be
         deferred.
         If now is not passed, the current timestamp is used.
         """
-        now = now if now is not None else time.time()
         next_timestamp = min(
             pt.croniter().get_next(ret_type=float, start_time=now)  # type: ignore
             for pt in self.periodic_tasks
         )
         return next_timestamp - now
 
-    def get_previous_tasks(self, now: Optional[float] = None) -> Iterable[TaskAtTime]:
+    def get_previous_tasks(self, now: float) -> Iterable[TaskAtTime]:
         """
         Return each periodic task that may not have been deferred yet, alongside with
         its scheduled time.
         Tasks that should have been deferred more than self.max_delay seconds ago are
         ignored.
         """
-        now = now if now is not None else time.time()
-
         known_schedule_keys = set(self.last_defers.items())
         for periodic_task in self.periodic_tasks:
             task = periodic_task.task

--- a/tests/acceptance/app.py
+++ b/tests/acceptance/app.py
@@ -108,4 +108,4 @@ counter = itertools.count()
 @cron_app.periodic(cron="* * * * * *")
 @cron_app.task()
 def tick(timestamp):
-    print(next(counter), timestamp)
+    print("tick", next(counter), timestamp)

--- a/tests/acceptance/test_nominal.py
+++ b/tests/acceptance/test_nominal.py
@@ -164,6 +164,10 @@ def test_periodic_deferrer(worker):
     print(stderr)
 
     # We're making a dict from the output
-    results = dict((int(a) for a in e.split()) for e in stdout.splitlines()[1:])
+    results = dict(
+        (int(a) for a in e[5:].split())
+        for e in stdout.splitlines()[1:]
+        if e.startswith("tick ")
+    )
     assert list(results)[:2] == [0, 1]
     assert results[1] == results[0] + 1

--- a/tests/unit/test_periodic.py
+++ b/tests/unit/test_periodic.py
@@ -59,14 +59,14 @@ def test_get_next_tick(deferrer, cron_task, cron, expected):
     cron_task(cron=cron)
 
     # Making things easier, we'll compute things next to timestamp 0
-    assert deferrer.get_next_tick(now=0) == expected
+    assert deferrer.get_next_tick(at=0) == expected
 
 
 def test_get_previous_tasks(deferrer, cron_task, task):
 
     cron_task(cron="* * * * *")
 
-    assert list(deferrer.get_previous_tasks(now=3600 * 24 - 1)) == [
+    assert list(deferrer.get_previous_tasks(at=3600 * 24 - 1)) == [
         (task, 3600 * 24 - 60)
     ]
 
@@ -77,7 +77,7 @@ def test_get_previous_tasks_known_schedule(deferrer, cron_task, task):
 
     deferrer.last_defers[task.name] = 3600 * 24 - 60
 
-    assert list(deferrer.get_previous_tasks(now=3600 * 24 - 1)) == []
+    assert list(deferrer.get_previous_tasks(at=3600 * 24 - 1)) == []
 
 
 def test_get_previous_tasks_too_old(deferrer, cron_task, task, caplog):
@@ -85,7 +85,7 @@ def test_get_previous_tasks_too_old(deferrer, cron_task, task, caplog):
     cron_task(cron="0 0 0 * *")
     caplog.set_level("DEBUG")
 
-    assert list(deferrer.get_previous_tasks(now=3600 * 24 - 1)) == []
+    assert list(deferrer.get_previous_tasks(at=3600 * 24 - 1)) == []
 
     assert [r.action for r in caplog.records] == ["ignore_periodic_task"]
 
@@ -112,7 +112,7 @@ async def test_worker_loop(job_store, mocker, task):
         async def wait(self, next_tick):
             mock.wait_next_tick(next_tick)
 
-        def get_next_tick(self, now):
+        def get_next_tick(self, at):
             return next(counter)
 
     mock_deferrer = MockPeriodicDeferrer(job_store=job_store)

--- a/tests/unit/test_periodic.py
+++ b/tests/unit/test_periodic.py
@@ -112,7 +112,7 @@ async def test_worker_loop(job_store, mocker, task):
         async def wait(self, next_tick):
             mock.wait_next_tick(next_tick)
 
-        def get_next_tick(self):
+        def get_next_tick(self, now):
             return next(counter)
 
     mock_deferrer = MockPeriodicDeferrer(job_store=job_store)


### PR DESCRIPTION
Closes #276 

This fixes #276 by making `get_previous_tasks` and `get_next_tick` always use the same value of `now`. See https://github.com/peopledoc/procrastinate/issues/276#issuecomment-676480721 for more detail.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing? (this was another fun "tests are flaky" problem!)
- [ ] (Maintainers: add PR labels)
