### PR TITLE
Mixed things around period tasks, locks and such

### DIFF
--- a/docs/howto/cron.rst
+++ b/docs/howto/cron.rst
@@ -36,21 +36,12 @@ When using periodic tasks there are a few things to know:
   your queue. If your workers are overwhelmed with long tasks, periodic executions could
   be delayed. One possible solution involves using queues to make sure short tasks are
   not delayed by long tasks.
-- Workers are responsible for deferring periodic tasks. If not a single worker is
-  running, then periodic tasks will not get scheduled. On the other hand, even if you
-  have multiple workers, periodic tasks will only be deferred once per period.
-- If a worker is occupied by a long-standing synchronous task, it will not be available
-  to defer periodic tasks. If you use sync tasks, ensure that at least one of your
-  workers is assigned tasks that are usually shorter to run than your shortest periodic
-  task interval. This is especially true for tasks that run every second.
-- When a worker wakes up, it will defer periodic tasks that have not been deferred yet
-  but:
-
-  - Only a single job for each task will be deferred (if a task is scheduled to run
-    every minute, and it missed 5 minutes, when the first worker starts, it will only
-    defer the last missed task, not the 4 previous ones).
-  - A task that is more than 10 minutes late will not be launched. This value is
-    configurable in the `App`.
+- Workers are responsible for deferring periodic tasks. If there is no worker running,
+  then periodic tasks will not get scheduled. On the other hand, even if you have
+  multiple workers, periodic tasks will only be deferred once per period.
+- When a worker starts, it will defer periodic tasks that have not been deferred yet
+  but a task that is more than 10 minutes late will not be deferred. This value is
+  configurable in the `App`.
 
 Periodic task arguments
 -----------------------

--- a/docs/howto/cron.rst
+++ b/docs/howto/cron.rst
@@ -78,6 +78,20 @@ plan to have the same value for every job::
     def run_healthchecks(timestamp: int):
         ...
 
+The value of those parameters is static, but you could put different values on different
+workers. If the same task is periodically deferred to different queues, each job will be
+independent::
+
+    @app.periodic(cron="*/5 * * * *")
+    @app.task(
+        queue=f"healthchecks_{my_worker_id}",
+    )
+    def run_healthchecks(timestamp: int):
+        ...
+
+In this setup, each worker (with differing values of ``my_worker_id``) would defer their
+own healthcheck jobs, independently from other workers.
+
 Using cron
 ----------
 

--- a/docs/howto/cron.rst
+++ b/docs/howto/cron.rst
@@ -61,6 +61,23 @@ in the past).
 
 .. __: https://en.wikipedia.org/wiki/Unix_time
 
+Queue, lock, queuing lock
+-------------------------
+
+Procrastinate itself takes care of deferring the periodic jobs, which means you don't
+have to opportunity to specify a given queue, lock or queueing lock at defer time.
+Fortunately, you can define all of those on the task itself, provided that you
+plan to have the same value for every job::
+
+    @app.periodic(cron="*/5 * * * *")
+    @app.task(
+        queue="healthchecks",
+        lock="healthchecks",
+        queueing_lock="healthchecks"
+    )
+    def run_healthchecks(timestamp: int):
+        ...
+
 Using cron
 ----------
 

--- a/docs/howto/defer.rst
+++ b/docs/howto/defer.rst
@@ -54,8 +54,7 @@ that runs the jobs. You can defer a job with just the name of its task.
     app.configure_task(name="my_module.my_task", queue="some_queue").defer(a=1, b=2)
 
 Any parameter you would use for `Task.configure` can be used in
-`configure_task`. Remember that the default queue declared on the task will not
-be used here. You need to define the queue or the job will use the ``"default"`` queue.
+`configure_task`.
 
 
 From the command line

--- a/docs/howto/locks.rst
+++ b/docs/howto/locks.rst
@@ -14,8 +14,8 @@ Or if we're deferring the same task with the same lock multiple times, we can ca
 configure just once::
 
     job_description = my_task.configure(lock=customer.id)
-    my_task.defer(a=1)
-    my_task.defer(a=2)
+    job_description.defer(a=1)
+    job_description.defer(a=2)
 
 In both cases, the second task cannot run before the first one
 has ended (successfully or not).
@@ -28,3 +28,10 @@ has ended (successfully or not).
 
     Similarly, if the oldest task of a lock is in a queue that no worker consumes, the
     other tasks are blocked.
+
+If you plan to use the same lock for every job deferred from the same task, you can
+define the value when you register the task::
+
+    @app.task(lock="my_lock_value")
+    def my_task(**kwargs):
+        ...

--- a/docs/howto/queueing_locks.rst
+++ b/docs/howto/queueing_locks.rst
@@ -23,3 +23,10 @@ In the command line interface (see `./defer`), you can use ``--queueing-lock`` a
 
     $ procrastinate defer --queueing-lock=maintenance --ignore-already-enqueued \
         my.maintenance.task
+
+If you plan to use the same queueing lock for every job deferred from the same task, you
+can define the value when you register the task::
+
+    @app.task(queueing_lock="my_lock_value")
+    def my_task(**kwargs):
+        ...

--- a/docs/howto/tasks.rst
+++ b/docs/howto/tasks.rst
@@ -7,7 +7,9 @@ You can specify a task with::
     def mytask(argument, other_argument):
         ...
 
-See `App.task` for the exact parameters.
+See `App.task` for the exact parameters. In particular, you can define values for
+``queue``, ``lock`` and  ``queueing_lock`` that will be used as default values when
+calling `Task.configure` or `Task.defer` on this task.
 
 If you're OK with all the default parameters, you can omit parentheses after
 ``task``::

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -107,11 +107,13 @@ class App:
         self,
         _func: Optional[Callable] = None,
         *,
-        queue: str = jobs.DEFAULT_QUEUE,
         name: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         retry: retry_module.RetryValue = False,
         pass_context: bool = False,
+        queue: str = jobs.DEFAULT_QUEUE,
+        lock: Optional[str] = None,
+        queueing_lock: Optional[str] = None,
     ) -> Any:
         """
         Declare a function as a task. This method is meant to be used as a decorator::
@@ -138,6 +140,10 @@ class App:
             Default is ``"default"``.
             When a worker is launched, it can listen to specific queues, or to all
             queues.
+        lock :
+            Default value for the ``lock`` (see `Task.defer`).
+        queueing_lock:
+            Default value for the ``queueing_lock`` (see `Task.defer`).
         name :
             Name of the task, by default the full dotted path to the decorated function.
             if the function is nested or dynamically defined, it is important to give
@@ -169,6 +175,8 @@ class App:
                 func,
                 app=self,
                 queue=queue,
+                lock=lock,
+                queueing_lock=queueing_lock,
                 name=name,
                 aliases=aliases,
                 retry=retry,

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -81,10 +81,11 @@ class App:
             Parameters for fine tuning the periodic tasks deferrer. Available
             parameters are:
 
-            - ``max_delay``: ``float``, in seconds, controls how long after the planned
-              launch of a periodic task a deferrer can launch the task. Thanks to this
-              parameter, when deploying a new periodic task, it's usually not deferred
-              until its next scheduled time. Defaults to 10 minutes.
+            - ``max_delay``: ``float``, in seconds. When a worker starts and there's
+              a periodic task that has not been deferred, the worker will defer the task
+              if it's been due for less that this amount of time. This avoids new
+              periodic tasks to be immediately deferred just after their first
+              deployment. (defaults to 10 minutes)
         """
         from procrastinate import periodic
 

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -252,8 +252,11 @@ def defer(
     configure_kwargs = filter_none(configure_kwargs)
 
     # Configure the job. If the task is known, it will be used.
-    job_deferrer = configure_job(
-        app=app, task_name=task, configure_kwargs=configure_kwargs, unknown=unknown
+    job_deferrer = configure_task(
+        app=app,
+        task_name=task,
+        configure_kwargs=configure_kwargs,
+        allow_unknown=unknown,
     )
 
     # Printing info
@@ -306,21 +309,15 @@ def get_schedule_in(in_: Optional[int]) -> Optional[Dict[str, int]]:
     return {"seconds": in_}
 
 
-def configure_job(
+def configure_task(
     app: procrastinate.App,
     task_name: str,
     configure_kwargs: Dict[str, Any],
-    unknown: bool,
+    allow_unknown: bool,
 ) -> jobs.JobDeferrer:
-    app.perform_import_paths()
-    try:
-        return app.tasks[task_name].configure(**configure_kwargs)
-
-    except KeyError:
-        if unknown:
-            return app.configure_task(name=task_name, **configure_kwargs)
-        else:
-            raise click.BadArgumentUsage(f"Task {task_name} not found.")
+    return app.configure_task(
+        name=task_name, allow_unknown=allow_unknown, **configure_kwargs
+    )
 
 
 @cli.command()

--- a/procrastinate/contrib/django/migrations/0012_add_locks_to_periodic_defer.py
+++ b/procrastinate/contrib/django/migrations/0012_add_locks_to_periodic_defer.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+from procrastinate.schema import get_sql
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("procrastinate", "0011_add_foreign_key_index")]
+
+    operations = [
+        migrations.RunSQL(get_sql("delta_0.14.0_001_add_locks_to_periodic_defer.sql")),
+    ]

--- a/procrastinate/sql/migrations/delta_0.14.0_001_add_locks_to_periodic_defer.sql
+++ b/procrastinate/sql/migrations/delta_0.14.0_001_add_locks_to_periodic_defer.sql
@@ -1,0 +1,47 @@
+DROP FUNCTION IF EXISTS procrastinate_defer_periodic_job;
+CREATE FUNCTION procrastinate_defer_periodic_job(
+    _queue_name character varying,
+    _lock character varying,
+    _queueing_lock character varying,
+    _task_name character varying,
+    _defer_timestamp bigint
+) RETURNS bigint
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+	_job_id bigint;
+	_defer_id bigint;
+BEGIN
+
+    INSERT
+        INTO procrastinate_periodic_defers (task_name, defer_timestamp)
+        VALUES (_task_name, _defer_timestamp)
+        ON CONFLICT DO NOTHING
+        RETURNING id into _defer_id;
+
+    IF _defer_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    UPDATE procrastinate_periodic_defers
+        SET job_id = procrastinate_defer_job(
+                _queue_name,
+                _task_name,
+                _lock,
+                _queueing_lock,
+                ('{"timestamp": ' || _defer_timestamp || '}')::jsonb,
+                NULL
+            )
+        WHERE id = _defer_id
+        RETURNING job_id INTO _job_id;
+
+    DELETE
+        FROM procrastinate_periodic_defers
+        WHERE
+            _job_id IS NOT NULL
+            AND procrastinate_periodic_defers.task_name = _task_name
+            AND procrastinate_periodic_defers.defer_timestamp < _defer_timestamp;
+
+    RETURN _job_id;
+END;
+$$;

--- a/procrastinate/sql/migrations/delta_0.14.0_001_add_locks_to_periodic_defer.sql
+++ b/procrastinate/sql/migrations/delta_0.14.0_001_add_locks_to_periodic_defer.sql
@@ -1,3 +1,15 @@
+ALTER TABLE procrastinate_periodic_defers
+    ADD COLUMN queue_name character varying(128) NOT NULL DEFAULT 'undefined';
+
+ALTER TABLE procrastinate_periodic_defers
+    ALTER COLUMN queue_name DROP DEFAULT;
+
+ALTER TABLE procrastinate_periodic_defers
+    DROP CONSTRAINT procrastinate_periodic_defers_task_name_defer_timestamp_key;
+
+ALTER TABLE procrastinate_periodic_defers
+    ADD CONSTRAINT procrastinate_periodic_defers_unique UNIQUE (task_name, queue_name, defer_timestamp);
+
 DROP FUNCTION IF EXISTS procrastinate_defer_periodic_job;
 CREATE FUNCTION procrastinate_defer_periodic_job(
     _queue_name character varying,
@@ -14,8 +26,8 @@ DECLARE
 BEGIN
 
     INSERT
-        INTO procrastinate_periodic_defers (task_name, defer_timestamp)
-        VALUES (_task_name, _defer_timestamp)
+        INTO procrastinate_periodic_defers (task_name, queue_name, defer_timestamp)
+        VALUES (_task_name, _queue_name, _defer_timestamp)
         ON CONFLICT DO NOTHING
         RETURNING id into _defer_id;
 

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -10,7 +10,7 @@ SELECT procrastinate_defer_job(%(queue)s, %(task_name)s, %(lock)s, %(queueing_lo
 -- defer_periodic_job --
 -- Create a periodic job if it doesn't already exist, and delete periodic metadata
 -- for previous jobs in the same task.
-SELECT procrastinate_defer_periodic_job(%(queue)s, %(task_name)s, %(defer_timestamp)s) AS id;
+SELECT procrastinate_defer_periodic_job(%(queue)s, %(lock)s, %(queueing_lock)s, %(task_name)s, %(defer_timestamp)s) AS id;
 
 -- fetch_job --
 -- Get the first awaiting job

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -40,7 +40,8 @@ CREATE TABLE procrastinate_periodic_defers (
     task_name character varying(128) NOT NULL,
     defer_timestamp bigint,
     job_id bigint REFERENCES procrastinate_jobs(id) NULL,
-    UNIQUE (task_name, defer_timestamp)
+    queue_name character varying(128) NOT NULL,
+    CONSTRAINT procrastinate_periodic_defers_unique UNIQUE (task_name, queue_name, defer_timestamp)
 );
 
 CREATE TABLE procrastinate_events (
@@ -100,8 +101,8 @@ DECLARE
 BEGIN
 
     INSERT
-        INTO procrastinate_periodic_defers (task_name, defer_timestamp)
-        VALUES (_task_name, _defer_timestamp)
+        INTO procrastinate_periodic_defers (task_name, queue_name, defer_timestamp)
+        VALUES (_task_name, _queue_name, _defer_timestamp)
         ON CONFLICT DO NOTHING
         RETURNING id into _defer_id;
 

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -87,6 +87,8 @@ $$;
 
 CREATE FUNCTION procrastinate_defer_periodic_job(
     _queue_name character varying,
+    _lock character varying,
+    _queueing_lock character varying,
     _task_name character varying,
     _defer_timestamp bigint
 ) RETURNS bigint
@@ -111,8 +113,8 @@ BEGIN
         SET job_id = procrastinate_defer_job(
                 _queue_name,
                 _task_name,
-                NULL,
-                NULL,
+                _lock,
+                _queueing_lock,
                 ('{"timestamp": ' || _defer_timestamp || '}')::jsonb,
                 NULL
             )

--- a/procrastinate/testing.py
+++ b/procrastinate/testing.py
@@ -122,15 +122,17 @@ class InMemoryConnector(connector.BaseAsyncConnector):
                 self.notify_event.set()
         return job_row
 
-    def defer_periodic_job_one(self, queue, task_name, defer_timestamp):
+    def defer_periodic_job_one(
+        self, queue, task_name, defer_timestamp, lock, queueing_lock
+    ):
         if self.periodic_defers.get(task_name) == defer_timestamp:
             return {"id": None}
         self.periodic_defers[task_name] = defer_timestamp
         return self.defer_job_one(
             task_name=task_name,
             queue=queue,
-            lock=None,
-            queueing_lock=None,
+            lock=lock,
+            queueing_lock=queueing_lock,
             args={"timestamp": defer_timestamp},
             scheduled_at=None,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ docs =
 docs_spelling =
     sphinxcontrib-spelling
 
-django = 
+django =
     django>=2.2
 
 [options.packages.find]

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -146,7 +146,10 @@ def test_defer_queueing_lock(entrypoint, click_app, connector):
     result = entrypoint("""-a yay defer --queueing-lock=houba hello {"a":2}""")
 
     assert result.exit_code > 0
-    assert "there is already a job in the queue with the lock houba" in result.output
+    assert (
+        "there is already a job in the queue with the queueing lock houba"
+        in result.output
+    )
     assert len(connector.jobs) == 1
 
 
@@ -163,7 +166,7 @@ def test_defer_queueing_lock_ignore(entrypoint, click_app, connector):
 
     assert result.exit_code == 0
     assert (
-        "there is already a job in the queue with the lock houba (ignored)"
+        "there is already a job in the queue with the queueing lock houba (ignored)"
         in result.output
     )
     assert len(connector.jobs) == 1

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 from procrastinate import app as app_module
-from procrastinate import exceptions, tasks
+from procrastinate import exceptions, retry, tasks
 
 from .. import conftest
 from .conftest import AsyncMock
@@ -19,15 +19,26 @@ def test_app_no_connector():
 
 
 def test_app_task_explicit(app, mocker):
-    @app.task(queue="a", name="b")
+    @app.task(
+        name="foobar",
+        queue="bar",
+        lock="sher",
+        queueing_lock="baz",
+        retry=True,
+        pass_context=True,
+    )
     def wrapped():
         return "foo"
 
-    assert "foo" == wrapped()
-    assert "b" == app.tasks["b"].name
-    assert "a" == app.tasks["b"].queue
-    assert app.tasks["b"] is wrapped
-    assert app.tasks["b"].func is wrapped.__wrapped__
+    assert wrapped() == "foo"
+    assert app.tasks["foobar"].name == "foobar"
+    assert app.tasks["foobar"].queue == "bar"
+    assert app.tasks["foobar"].lock == "sher"
+    assert app.tasks["foobar"].queueing_lock == "baz"
+    assert isinstance(app.tasks["foobar"].retry_strategy, retry.RetryStrategy)
+    assert app.tasks["foobar"].pass_context is True
+    assert app.tasks["foobar"] is wrapped
+    assert app.tasks["foobar"].func is wrapped.__wrapped__
 
 
 def test_app_task_aliases(app, mocker):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -105,25 +105,25 @@ def test_get_schedule_in(input, output):
     assert cli.get_schedule_in(input) == output
 
 
-def test_configure_job_known(app):
+def test_configure_task_known(app):
     @app.task(name="foobar", queue="marsupilami")
     def mytask():
         pass
 
-    job = cli.configure_job(app, "foobar", {}, unknown=False).job
+    job = cli.configure_task(app, "foobar", {}, allow_unknown=False).job
     assert job.task_name == "foobar"
     assert job.queue == "marsupilami"
 
 
-def test_configure_job_unknown(app):
-    job = cli.configure_job(app, "foobar", {}, unknown=True).job
+def test_configure_task_unknown(app):
+    job = cli.configure_task(app, "foobar", {}, allow_unknown=True).job
     assert job.task_name == "foobar"
     assert job.queue == "default"
 
 
-def test_test_configure_job_error(app):
-    with pytest.raises(click.BadArgumentUsage):
-        assert cli.configure_job(app, "foobar", {}, unknown=False)
+def test_test_configure_task_error(app):
+    with pytest.raises(exceptions.TaskNotFound):
+        assert cli.configure_task(app, "foobar", {}, allow_unknown=False)
 
 
 def test_filter_none():

--- a/tests/unit/test_periodic.py
+++ b/tests/unit/test_periodic.py
@@ -6,7 +6,7 @@ from procrastinate import periodic
 
 
 @pytest.fixture
-def deferrer(job_store):
+def periodic_deferrer(job_store):
     return periodic.PeriodicDeferrer(job_store=job_store)
 
 
@@ -20,25 +20,25 @@ def task(app):
 
 
 @pytest.fixture
-def cron_task(deferrer, task):
+def cron_task(periodic_deferrer, task):
     def _(cron="0 0 * * *"):
-        return deferrer.register_task(task=task, cron=cron)
+        return periodic_deferrer.register_task(task=task, cron=cron)
 
     return _
 
 
-def test_register_task(deferrer, task):
-    deferrer.register_task(task=task, cron="0 0 * * *")
+def test_register_task(periodic_deferrer, task):
+    periodic_deferrer.register_task(task=task, cron="0 0 * * *")
 
-    assert deferrer.periodic_tasks == [
+    assert periodic_deferrer.periodic_tasks == [
         periodic.PeriodicTask(task=task, cron="0 0 * * *")
     ]
 
 
-def test_schedule_decorator(deferrer, task):
-    deferrer.periodic_decorator(cron="0 0 * * *")(task)
+def test_schedule_decorator(periodic_deferrer, task):
+    periodic_deferrer.periodic_decorator(cron="0 0 * * *")(task)
 
-    assert deferrer.periodic_tasks == [
+    assert periodic_deferrer.periodic_tasks == [
         periodic.PeriodicTask(task=task, cron="0 0 * * *")
     ]
 
@@ -53,47 +53,47 @@ def test_schedule_decorator(deferrer, task):
         ("* * * * * */5", 5),
     ],
 )
-def test_get_next_tick(deferrer, cron_task, cron, expected):
+def test_get_next_tick(periodic_deferrer, cron_task, cron, expected):
 
     cron_task(cron="0 0 * * *")
     cron_task(cron=cron)
 
     # Making things easier, we'll compute things next to timestamp 0
-    assert deferrer.get_next_tick(at=0) == expected
+    assert periodic_deferrer.get_next_tick(at=0) == expected
 
 
-def test_get_previous_tasks(deferrer, cron_task, task):
+def test_get_previous_tasks(periodic_deferrer, cron_task, task):
 
     cron_task(cron="* * * * *")
 
-    assert list(deferrer.get_previous_tasks(at=3600 * 24 - 1)) == [
+    assert list(periodic_deferrer.get_previous_tasks(at=3600 * 24 - 1)) == [
         (task, 3600 * 24 - 60)
     ]
 
 
-def test_get_previous_tasks_known_schedule(deferrer, cron_task, task):
+def test_get_previous_tasks_known_schedule(periodic_deferrer, cron_task, task):
 
     cron_task(cron="* * * * *")
 
-    deferrer.last_defers[task.name] = 3600 * 24 - 60
+    periodic_deferrer.last_defers[task.name] = 3600 * 24 - 60
 
-    assert list(deferrer.get_previous_tasks(at=3600 * 24 - 1)) == []
+    assert list(periodic_deferrer.get_previous_tasks(at=3600 * 24 - 1)) == []
 
 
-def test_get_previous_tasks_too_old(deferrer, cron_task, task, caplog):
+def test_get_previous_tasks_too_old(periodic_deferrer, cron_task, task, caplog):
 
     cron_task(cron="0 0 0 * *")
     caplog.set_level("DEBUG")
 
-    assert list(deferrer.get_previous_tasks(at=3600 * 24 - 1)) == []
+    assert list(periodic_deferrer.get_previous_tasks(at=3600 * 24 - 1)) == []
 
     assert [r.action for r in caplog.records] == ["ignore_periodic_task"]
 
 
 @pytest.mark.asyncio
-async def test_worker_no_task(deferrer, caplog):
+async def test_worker_no_task(periodic_deferrer, caplog):
     caplog.set_level("INFO")
-    await deferrer.worker()
+    await periodic_deferrer.worker()
 
     assert [r.action for r in caplog.records] == ["periodic_deferrer_no_task"]
 
@@ -131,19 +131,19 @@ async def test_worker_loop(job_store, mocker, task):
 
 
 @pytest.mark.asyncio
-async def test_wait_next_tick(deferrer, mocker):
+async def test_wait_next_tick(periodic_deferrer, mocker):
     async def wait(val):
         assert val == 5 + periodic.MARGIN
 
     mocker.patch("asyncio.sleep", wait)
 
-    await deferrer.wait(5)
+    await periodic_deferrer.wait(5)
 
 
 @pytest.mark.asyncio
-async def test_defer_jobs(deferrer, task, connector, caplog):
+async def test_defer_jobs(periodic_deferrer, task, connector, caplog):
     caplog.set_level("DEBUG")
-    await deferrer.defer_jobs([(task, 1)])
+    await periodic_deferrer.defer_jobs([(task, 1)])
 
     assert connector.queries == [
         (
@@ -151,6 +151,8 @@ async def test_defer_jobs(deferrer, task, connector, caplog):
             {
                 "queue": "default",
                 "defer_timestamp": 1,
+                "lock": None,
+                "queueing_lock": None,
                 "task_name": "tests.unit.test_periodic.foo",
             },
         )
@@ -159,11 +161,11 @@ async def test_defer_jobs(deferrer, task, connector, caplog):
 
 
 @pytest.mark.asyncio
-async def test_defer_jobs_already(deferrer, task, connector, caplog):
+async def test_defer_jobs_already(periodic_deferrer, task, connector, caplog):
     caplog.set_level("DEBUG")
     connector.periodic_defers[task.name] = 1
 
-    await deferrer.defer_jobs([(task, 1)])
+    await periodic_deferrer.defer_jobs([(task, 1)])
 
     assert connector.queries == [
         (
@@ -171,8 +173,28 @@ async def test_defer_jobs_already(deferrer, task, connector, caplog):
             {
                 "queue": "default",
                 "defer_timestamp": 1,
+                "lock": None,
+                "queueing_lock": None,
                 "task_name": "tests.unit.test_periodic.foo",
             },
         )
     ]
     assert [r.action for r in caplog.records] == ["periodic_task_already_deferred"]
+
+
+@pytest.mark.asyncio
+async def test_defer_jobs_queueing_lock(periodic_deferrer, app, connector, caplog):
+    caplog.set_level("DEBUG")
+
+    @app.task(queueing_lock="sher")
+    def foo(timestamp):
+        pass
+
+    caplog.clear()
+
+    await periodic_deferrer.defer_jobs([(foo, 1), (foo, 2)])
+
+    assert [r.action for r in caplog.records] == [
+        "periodic_task_deferred",
+        "skip_periodic_task_queueing_lock",
+    ]


### PR DESCRIPTION
Ok, I've just thrown away code together for discussion. No tests, no docs, it's just for wrapping our heads around the several linked problems.

Fixes #295: app.configure_task uses tasks defaults when they exist
Related to #292: tasks accept default lock and queuing lock
Related to #292: Periodic jobs use task default lock and queueing lock
Closes #289: same periodic tasks on different queues can coexist
Fixes #292: periodic deferrer doesn't miss tasks anymore 

Of course, we can extract each of these subjects in its own PR.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)
- [x] Had a good time contributing?
- [ ] (Maintainers: add PR labels)
