### PR TITLE
Update codebase with black's new trailing commas rule

### DIFF
--- a/procrastinate/admin.py
+++ b/procrastinate/admin.py
@@ -188,7 +188,7 @@ class Admin:
             ``lock``, ``args``, ``status``, ``scheduled_at``, ``attempts``).
         """
         await self.connector.execute_query_async(
-            query=sql.queries["set_job_status"], id=id, status=status,
+            query=sql.queries["set_job_status"], id=id, status=status
         )
         (result,) = await self.list_jobs_async(id=id)
         return result

--- a/procrastinate/aiopg_connector.py
+++ b/procrastinate/aiopg_connector.py
@@ -236,7 +236,7 @@ class AiopgConnector(connector.BaseAsyncConnector):
     @wrap_exceptions
     @wrap_query_exceptions
     async def _execute_query_connection(
-        self, query: str, connection: aiopg.Connection, **arguments: Any,
+        self, query: str, connection: aiopg.Connection, **arguments: Any
     ) -> None:
         async with connection.cursor() as cursor:
             await cursor.execute(query, self._wrap_json(arguments))

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -330,7 +330,7 @@ def configure_task(
     default=True,
 )
 @click.option(
-    "--read", "action", flag_value="read", help="Read the schema SQL and output it",
+    "--read", "action", flag_value="read", help="Read the schema SQL and output it"
 )
 @click.option(
     "--migrations-path",

--- a/procrastinate/periodic.py
+++ b/procrastinate/periodic.py
@@ -107,13 +107,13 @@ class PeriodicDeferrer:
             name = task.name
 
             for timestamp in self.get_timestamps(
-                periodic_task=periodic_task, since=self.last_defers.get(name), until=at,
+                periodic_task=periodic_task, since=self.last_defers.get(name), until=at
             ):
                 self.last_defers[name] = timestamp
                 yield task, timestamp
 
     def get_timestamps(
-        self, periodic_task: PeriodicTask, since: Optional[int], until: float,
+        self, periodic_task: PeriodicTask, since: Optional[int], until: float
     ) -> Iterable[int]:
         cron_iterator = periodic_task.croniter()
         if since:

--- a/procrastinate/psycopg2_connector.py
+++ b/procrastinate/psycopg2_connector.py
@@ -136,9 +136,7 @@ class Psycopg2Connector(connector.BaseConnector):
         final_args.update(pool_args)
         return final_args
 
-    def open(
-        self, pool: Optional[psycopg2.pool.AbstractConnectionPool] = None,
-    ) -> None:
+    def open(self, pool: Optional[psycopg2.pool.AbstractConnectionPool] = None) -> None:
         """
         Instantiate the pool.
 

--- a/procrastinate/store.py
+++ b/procrastinate/store.py
@@ -17,9 +17,7 @@ def get_channel_for_queues(queues: Optional[Iterable[str]] = None) -> Iterable[s
 
 
 class JobStore:
-    def __init__(
-        self, connector: connector.BaseConnector,
-    ):
+    def __init__(self, connector: connector.BaseConnector):
         self.connector = connector
 
     async def defer_job_async(self, job: jobs.Job) -> int:
@@ -142,7 +140,7 @@ class JobStore:
         )
 
     async def listen_for_jobs(
-        self, *, event: asyncio.Event, queues: Optional[Iterable[str]] = None,
+        self, *, event: asyncio.Event, queues: Optional[Iterable[str]] = None
     ) -> None:
         await self.connector.listen_notify(
             event=event, channels=get_channel_for_queues(queues=queues)

--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -82,7 +82,7 @@ class Worker:
 
     def periodic_deferrer(self):
         return utils.task_context(
-            awaitable=self.app.periodic_deferrer.worker(), name="periodic_deferrer",
+            awaitable=self.app.periodic_deferrer.worker(), name="periodic_deferrer"
         )
 
     async def run(self) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
 [options.extras_require]
 dev =
     tox
-    black
+    black>=20.8b1
     isort>=5.0.0
 
 test =
@@ -49,9 +49,9 @@ test =
     pum
 
 lint =
-    black
+    black>=20.8b1
     flake8
-    isort
+    isort>=5.0.0
     mypy
     check-manifest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,7 +191,7 @@ def job_factory(serial, random_str):
 
 
 def aware_datetime(
-    year, month, day, hour=0, minute=0, second=0, microsecond=0, tz_offset=None,
+    year, month, day, hour=0, minute=0, second=0, microsecond=0, tz_offset=None
 ):
     tzinfo = (
         datetime.timezone(datetime.timedelta(hours=tz_offset))

--- a/tests/unit/test_aiopg_connector.py
+++ b/tests/unit/test_aiopg_connector.py
@@ -152,7 +152,7 @@ async def test_listen_notify_pool_one_connection(mocker, caplog):
 @pytest.fixture
 def mock_async_create_pool(mocker):
     return mocker.patch.object(
-        aiopg_connector.AiopgConnector, "_create_pool", return_value=AsyncMock(),
+        aiopg_connector.AiopgConnector, "_create_pool", return_value=AsyncMock()
     )
 
 

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -101,7 +101,7 @@ def test_app_worker(app, mocker):
     app._worker(queues=["yay"], name="w1", wait=False)
 
     Worker.assert_called_once_with(
-        queues=["yay"], app=app, name="w1", timeout=12, wait=False,
+        queues=["yay"], app=app, name="w1", timeout=12, wait=False
     )
 
 
@@ -143,7 +143,7 @@ def test_app_configure_task_unknown_allowed(app):
 
     scheduled_at = conftest.aware_datetime(2000, 1, 1)
     job = app.configure_task(
-        name="my_name", lock="sher", schedule_at=scheduled_at, task_kwargs={"a": 1},
+        name="my_name", lock="sher", schedule_at=scheduled_at, task_kwargs={"a": 1}
     ).job
 
     assert job.task_name == "my_name"

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -57,7 +57,11 @@ def test_get_schedule_in_time(
 
 
 @pytest.mark.parametrize(
-    "exception, expected", [(ValueError(), 0), (KeyError(), None)],
+    "exception, expected",
+    [
+        (ValueError(), 0),
+        (KeyError(), None),
+    ],
 )
 def test_get_schedule_in_exception(exception, expected):
     strategy = retry_module.RetryStrategy(retry_exceptions=[ValueError])

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -6,7 +6,7 @@ from procrastinate import shell as shell_module
 
 @pytest.fixture
 def shell(connector):
-    return shell_module.ProcrastinateShell(admin.Admin(connector=connector),)
+    return shell_module.ProcrastinateShell(admin.Admin(connector=connector))
 
 
 def test_exit(shell):

--- a/tests/unit/test_sql.py
+++ b/tests/unit/test_sql.py
@@ -2,9 +2,8 @@ from procrastinate import sql
 
 
 def test_parse_query_file():
-    assert (
-        sql.parse_query_file(
-            """
+    assert sql.parse_query_file(
+        """
 -- Hello: This is ignored.
 yay
 
@@ -21,13 +20,11 @@ SELECT blu
 -- description
 INSERT INTO blou VALUES(%(yay)s)
     """
-        )
-        == {
-            "query1": "Select bla",
-            "query2": "SELECT blu",
-            "query3": "INSERT INTO blou VALUES(%(yay)s)",
-        }
-    )
+    ) == {
+        "query1": "Select bla",
+        "query2": "SELECT blu",
+        "query3": "INSERT INTO blou VALUES(%(yay)s)",
+    }
 
 
 def test_get_queries():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -338,7 +338,7 @@ def test_parse_datetime(input, expected):
 def mock_awaitable_context():
     open_mock, close_mock = AsyncMock(), AsyncMock()
     return utils.AwaitableContext(
-        open_coro=lambda: open_mock, close_coro=lambda: close_mock, return_value=1,
+        open_coro=lambda: open_mock, close_coro=lambda: close_mock, return_value=1
     )
 
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -64,9 +64,7 @@ async def test_process_job(
 
     await test_worker.process_job(job=job)
 
-    test_worker.run_job.assert_called_with(
-        job=job, worker_id=0,
-    )
+    test_worker.run_job.assert_called_with(job=job, worker_id=0)
     assert connector.jobs[1]["status"] == status
 
 


### PR DESCRIPTION
Closes #304

Ping @elemoine @thomasperrot @mgu :)

Black now works this way for a comma-separated sequence:
- If it doesn't fit in one line, it will be split in 1 element per line and there will be a trailing comma
- If either could fit then it's up to **you** to either put a trailing comma and force 1 element per line or not put a trailing comma and force 1 line.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
- [x] (Maintainers: add PR labels)
