### PR TITLE
Fix the demo

### DIFF
--- a/procrastinate_demo/__main__.py
+++ b/procrastinate_demo/__main__.py
@@ -40,8 +40,8 @@ async def main_async():
 
 if __name__ == "__main__":
     logging.basicConfig(level="DEBUG")
-    if app.is_async:
+    if app.USE_ASYNC:
         asyncio.get_event_loop().run_until_complete(main_async())
-        # asyncio.run(main_async())  # python3.7 only
+        # asyncio.run(main_async())  # Python 3.7+
     else:
         main()

--- a/procrastinate_demo/app.py
+++ b/procrastinate_demo/app.py
@@ -1,15 +1,14 @@
 import procrastinate
 
+USE_ASYNC = True
+
+
 import_paths = ["procrastinate_demo.tasks"]
-is_async = False  # set to True to run async demo
-if is_async:
+
+if USE_ASYNC:
     connector_class = procrastinate.AiopgConnector
 else:
     connector_class = procrastinate.Psycopg2Connector
 
-app = procrastinate.App(
-    connector=connector_class(),
-    import_paths=import_paths,
-    worker_defaults={"listen_notify": False},
-)
+app = procrastinate.App(connector=connector_class(), import_paths=import_paths)
 app.open()


### PR DESCRIPTION
Closes #309 

Make `USE_ASYNC` default to `True` in `procrastinate_demo/app.py`. This is for `procrastinate worker` to work without having to change `USE_ASYNC` from `False` to `True`.

I also took the opportunity to re-enable the listen/notify mechanism in the demo (https://github.com/peopledoc/procrastinate/commit/2df7cc5ceb26295cf94d5cb2e5f6b3dd174850d1#diff-845b0890ea23363d7fbc173f1a9d06a2 disabled it, probably by accident.)

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)
- [x] Had a good time contributing?
- [x] (Maintainers: add PR labels)
