### PR TITLE
Use postgres:12 image for faster tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,6 @@ jobs:
           --health-timeout 5s
         ports:
           - 5432:5432
-        command: ["-c", "fsync=off"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
           --health-timeout 5s
         ports:
           - 5432:5432
+        command: ["-c", "fsync=off"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:12
         env:
           POSTGRES_DB: procrastinate
           POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,4 @@ services:
     environment:
         POSTGRES_DB: procrastinate
         POSTGRES_PASSWORD: password
+    command: ["-c", "fsync=off"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - postgres
     user: ${UID:-0}:${GID:-0}
   postgres:
-    image: postgres:10
+    image: postgres:12
     ports: ["5432:5432"]
     environment:
         POSTGRES_DB: procrastinate


### PR DESCRIPTION
This PR suggests to use the postgres:12 image rather than postgres:10 for much much faster tests!


|                            | postgres:10 | postgres:11     | postgres:12 | postgres:12 w/ fsync=off
|-----------------------|----------------|-------------------|-----------------|---------------------------------
| unit tests             | 2.5s            | 2.5s                | 2.5s              | 2.5s
| integration tests   | 35s             | 30s                 | 9s                 | 6s
| acceptance tests | 22s             | 21s                 | 18s               | 17s
| migration tests    | 4s               | 4s                   | 3s                 | 3s
| all the tests         | 1m             | 54s                  | 28s                | 25s

We save 3 additional seconds by setting `fsync` to `off`. 

### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
- [ ] (Maintainers: add PR labels)
