### PR TITLE
Set postgres fsync to off in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,3 @@ services:
     environment:
         POSTGRES_DB: procrastinate
         POSTGRES_PASSWORD: password
-    command: ["-c", "fsync=off"]


### PR DESCRIPTION
This is to have the same Postgres config locally and in the CI.


<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
- [ ] (Maintainers: add PR labels)
