### PR TITLE
Use dunamai to get version from Git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           set -xeu
           python -VV
-          pip install setuptools wheel
+          pip install setuptools wheel dunamai
       - name: Build the wheel
         run: python setup.py sdist bdist_wheel
       - name: Publish to PyPI

--- a/dev-env
+++ b/dev-env
@@ -22,6 +22,7 @@ echo ""
 
 if ! ls .venv/lib/python*/site-packages/procrastinate.egg-link 1>/dev/null 2>&1; then
     echo "Installing package for development"
+    pip install dunamai
     pip install -r requirements.txt
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import contextlib
 import os
 import pathlib
-import subprocess
 
 import setuptools
 
@@ -19,19 +18,12 @@ def ensure_version():
         pass
 
     # If running from the git repository
-    try:
-        version = (
-            subprocess.check_output(["git", "describe", "--tags"])
-            .decode("utf-8")
-            .strip()
-            .replace("-", "+", 1)
-            .replace("-", ".")
-        )
-    except subprocess.CalledProcessError:
-        # This might happen in some rare cases, like when running check-manifest.
-        # We'll update this to something better if it ever proves problematic.
-        yield "0.0.0"
-        return
+    import dunamai
+
+    version_pattern = (
+        r"^(?P<base>\d+\.\d+\.\d+)(-?((?P<stage>[a-zA-Z]+)\.?(?P<revision>\d+)?))?$"
+    )
+    version = dunamai.Version.from_git(pattern=version_pattern).serialize()
 
     try:
         with open(version_filename, "w") as f:


### PR DESCRIPTION
Refs https://github.com/peopledoc/procrastinate/issues/242

Use dunamai to get version from Git.

The main issue with this is that we need to have dunamai installed prior to being able to do `pip install -r requirements.txt` (or `pip install -e .`).

Closes #<ticket number>

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)
- [ ] Had a good time contributing?
- [ ] (Maintainers: add PR labels)
