### PR TITLE
Report test workflow success in Check API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,15 +92,12 @@ jobs:
         with:
           fail_ci_if_error: true
 
-  report-success:
-    name: Report success in Github Checks
+  report-status:
+    name: ${{ github.event_name }}-success
     runs-on: ubuntu-latest
     needs:
       - check-lint
       - tests
     steps:
-      - uses: LouisBrunner/checks-action@v0.1.0
-        with:
-          name: Test
-          token: ${{ secrets.GITHUB_TOKEN }}
-          conclusion: ${{ job.status }}
+      - name: Report success
+        run: echo 'Success !'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           fail_ci_if_error: true
 
   report-status:
-    name: ${{ github.event_name }}-success
+    name: success
     runs-on: ubuntu-latest
     needs:
       - check-lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         id: wait-for-ci
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: push-success
+          checkName: success
       - name: Exit if CI did not succeed
         if: steps.wait-for-ci.outputs.conclusion != 'success'
         run: exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - published
+
+jobs:
+  deploy:
+    name: Publish package to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for tests to succeed
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-ci
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: push-success
+      - name: Exit if CI did not succeed
+        if: steps.wait-for-ci.outputs.conclusion != 'success'
+        run: exit 1
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          set -xeu
+          python -VV
+          pip install setuptools wheel
+      - name: Build the wheel
+        run: python setup.py sdist bdist_wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,6 @@ on:
     tags:
       - '*'
   pull_request:
-  release:
-    types:
-      - published
 
 jobs:
   check-lint:
@@ -95,28 +92,15 @@ jobs:
         with:
           fail_ci_if_error: true
 
-  deploy:
-    name: Publish package to PyPI
+  report-success:
+    name: Report success in Github Checks
     runs-on: ubuntu-latest
     needs:
       - check-lint
       - tests
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'release'
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - uses: LouisBrunner/checks-action@v0.1.0
         with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          set -xeu
-          python -VV
-          pip install -U pip build
-      - name: Build the wheel
-        run: python -m build --sdist --wheel
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          name: Test
+          token: ${{ secrets.GITHUB_TOKEN }}
+          conclusion: ${{ job.status }}


### PR DESCRIPTION
Closes #321 

What we want to do:
- create two new checks: `push-success` and `pull_request-success`, that are created when their workflow succeed
- enable PR merge only when the above checks are successfull (need to configure that in the repository settings)
- enable deploying only when `push-success` on the last master HEAD is succussfull


<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [X] (not applicable?)
- [ ] Documentation
  - [X] (not applicable?)
- [X] Had a good time contributing?
- [x] (Maintainers: add PR labels)
