### PR TITLE
Change name of short option for --listen-notifiy

### DIFF
--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -162,7 +162,7 @@ def close_connection(procrastinate_app: procrastinate.App, *args, **kwargs):
     "terminate or to wait for new jobs",
 )
 @click.option(
-    "-w",
+    "-l",
     "--listen-notify/--no-listen-notify",
     default=True,
     help="Whether to actively listen for new jobs or periodically poll",


### PR DESCRIPTION
The short option name "-w" is already used for "--wait".

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
