### PR TITLE
Split procrastinate_finish_job into two functions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -333,6 +333,13 @@ care of removing the old version of the function:
 In this way, you provide the new SQL code, the compatibility layer, and the migration
 for the removal of the compatibility layer.
 
+.. note::
+
+    The migration scripts that remove the SQL compatibility code are to be added to the
+    ``future_migrations`` directory instead of the ``migrations`` directory. And it will
+    be the responsibility of Procrastinate maintainers to move them to the
+    ``migrations`` directory after the next major release.
+
 Migration tests
 ^^^^^^^^^^^^^^^
 
@@ -516,3 +523,8 @@ it to PyPI (using the new API tokens). That tag should also trigger a ReadTheDoc
 build, which will read GitHub releases (thanks to our ``changelog`` extension)
 which will  write the changelog in the published documentation (transformed from
 ``Markdown`` to ``RestructuredText``).
+
+After a new major version is released (e.g. ``2.0.0``), in preparation for the next
+minor release (``2.1.0``), the migration scripts in the ``future_migrations`` directory
+that remove the SQL compatibility code must be moved to the ``migrations`` directory.
+And the ``schema.sql`` file must be updated accordingly.

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -129,14 +129,23 @@ class JobManager:
         self,
         job: jobs.Job,
         status: jobs.Status,
-        scheduled_at: Optional[datetime.datetime] = None,
     ) -> None:
         assert job.id  # TODO remove this
         await self.connector.execute_query_async(
             query=sql.queries["finish_job"],
             job_id=job.id,
             status=status.value,
-            scheduled_at=scheduled_at,
+        )
+
+    async def retry_job(
+        self,
+        job: jobs.Job,
+        retry_at: datetime.datetime,
+    ) -> None:
+        await self.connector.execute_query_async(
+            query=sql.queries["retry_job"],
+            job_id=job.id,
+            retry_at=retry_at,
         )
 
     async def listen_for_jobs(

--- a/procrastinate/sql/future_migrations/01.00.00_01_remove_old_finish_job_function.sql
+++ b/procrastinate/sql/future_migrations/01.00.00_01_remove_old_finish_job_function.sql
@@ -1,0 +1,3 @@
+-- remove old procrastinate_finish_job function
+-- https://github.com/peopledoc/procrastinate/pull/336
+DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status, timestamp with time zone);

--- a/procrastinate/sql/migrations/00.16.00_01_add_finish_job_and_retry_job_functions.sql
+++ b/procrastinate/sql/migrations/00.16.00_01_add_finish_job_and_retry_job_functions.sql
@@ -1,0 +1,22 @@
+CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    UPDATE procrastinate_jobs
+    SET status = end_status,
+        attempts = attempts + 1
+    WHERE id = job_id;
+END;
+$$;
+
+CREATE FUNCTION procrastinate_retry_job(job_id integer, retry_at timestamp with time zone) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    UPDATE procrastinate_jobs
+    SET status = 'todo',
+        attempts = attempts + 1,
+        scheduled_at = retry_at
+    WHERE id = job_id;
+END;
+$$;

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -47,8 +47,12 @@ WHERE id IN (
 )
 
 -- finish_job --
--- Stop a job, free the lock and record the relevant events
-SELECT procrastinate_finish_job(%(job_id)s, %(status)s, %(scheduled_at)s);
+-- Finish a job, changing it from "doing" to "succeeded" or "failed"
+SELECT procrastinate_finish_job(%(job_id)s, %(status)s);
+
+-- retry_job --
+-- Retry a job, changing it from "doing" to "todo"
+SELECT procrastinate_retry_job(%(job_id)s, %(retry_at)s);
 
 -- listen_queue --
 -- In this one, the argument is an identifier, shoud not be escaped the same way

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -172,6 +172,7 @@ BEGIN
 END;
 $$;
 
+-- procrastinate_finish_job – old version
 CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone) RETURNS void
     LANGUAGE plpgsql
     AS $$
@@ -180,6 +181,30 @@ BEGIN
     SET status = end_status,
         attempts = attempts + 1,
         scheduled_at = COALESCE(next_scheduled_at, scheduled_at)
+    WHERE id = job_id;
+END;
+$$;
+
+-- procrastinate_finish_job – new version
+CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    UPDATE procrastinate_jobs
+    SET status = end_status,
+        attempts = attempts + 1
+    WHERE id = job_id;
+END;
+$$;
+
+CREATE FUNCTION procrastinate_retry_job(job_id integer, retry_at timestamp with time zone) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    UPDATE procrastinate_jobs
+    SET status = 'todo',
+        attempts = attempts + 1,
+        scheduled_at = retry_at
     WHERE id = job_id;
 END;
 $$;

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -173,6 +173,7 @@ END;
 $$;
 
 -- procrastinate_finish_job – old version
+-- to remove after 1.0.0 is released
 CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone) RETURNS void
     LANGUAGE plpgsql
     AS $$
@@ -185,7 +186,7 @@ BEGIN
 END;
 $$;
 
--- procrastinate_finish_job – new version
+-- procrastinate_finish_job
 CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status) RETURNS void
     LANGUAGE plpgsql
     AS $$

--- a/tests/migration/pgservice.ini
+++ b/tests/migration/pgservice.ini
@@ -1,4 +1,0 @@
-[procrastinate_schema]
-dbname=procrastinate_schema
-[procrastinate_migrations]
-dbname=procrastinate_migrations

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -120,14 +120,23 @@ async def test_delete_old_jobs(
 async def test_finish_job(job_manager, job_factory, connector):
     job = job_factory(id=1)
     await job_manager.defer_job_async(job=job)
-    retry_at = conftest.aware_datetime(2000, 1, 1)
 
-    await job_manager.finish_job(
-        job=job, status=jobs.Status.TODO, scheduled_at=retry_at
-    )
+    await job_manager.finish_job(job=job, status=jobs.Status.TODO)
     assert connector.queries[-1] == (
         "finish_job",
-        {"job_id": 1, "scheduled_at": retry_at, "status": "todo"},
+        {"job_id": 1, "status": "todo"},
+    )
+
+
+async def test_retry_job(job_manager, job_factory, connector):
+    job = job_factory(id=1)
+    await job_manager.defer_job_async(job=job)
+    retry_at = conftest.aware_datetime(2000, 1, 1)
+
+    await job_manager.retry_job(job=job, retry_at=retry_at)
+    assert connector.queries[-1] == (
+        "retry_job",
+        {"job_id": 1, "retry_at": retry_at},
     )
 
 


### PR DESCRIPTION
Closes #332 

This PR splits the `procrastinate_finish_job` SQL functions into two functions: `procrastinate_finish_job` and `procrastinate_retry_job`.

To be discussed:

For backward compatibility reasons I've kept `procrastinate_finish_job` as-is, and added `procrastinate_finish_job_1`. In this way one can apply the schema migration (the `delta_0.16.0_001` SQL file in this PR) before upgrading the Procrastinate code.

I think that the schema of Procrastinate version N should work for any previous version (< N) of Procrastinate. This is to make it easy to upgrade Procrastinate, and in a "blue/green" way. And I think we should do that until 1.0. In 1.0 we would remove all the backward compatibility stuff from the schema. For example, we would rename `procrastinate_finish_job_1` to `procrastinate_finish_job`, and remove the old `procrastinate_finish_job` function. And we would apply the same backward compatibility principle within the 1.x.y series (until 2.0.0).

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
