### PR TITLE
Use underscores in migration script names

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -320,9 +320,9 @@ greatly help the Procrastinate maintainers.
 For example, let's say the current released version of Procrastinate is 1.5.0, and you
 want to change the signature of ``procrastinate_func`` as described above. You will add
 a ``1.5.0`` migration script (e.g.
-``delta_1.5.0_001_add-new-version-procrastinate-func.sql``) that adds the new version of
+``delta_1.5.0_001_add_new_version_procrastinate_func.sql``) that adds the new version of
 the function, as already described above. And you will also add a ``2.0.0`` migration
-script (e.g. ``delta_2.0.0_001_remove-old-version-procrastinate-func.sql``) that takes
+script (e.g. ``delta_2.0.0_001_remove_old_version_procrastinate_func.sql``) that takes
 care of removing the old version of the function:
 
 .. code-block:: sql


### PR DESCRIPTION
Above in the CONTRIBUTING guide we say that underscores must be used as the word separator in the short description of migration scripts. So let's be consistent and use the proper notation in the rest of the guide.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
