### PR TITLE
Fix the shell's "retry job" and "cancel job" actions

### DIFF
--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -91,11 +91,11 @@ class Job:
             attempts=row["attempts"],
         )
 
-    def asdict(self) -> types.JSONDict:
+    def asdict(self) -> Dict[str, Any]:
         return attr.asdict(self)
 
     def log_context(self) -> types.JSONDict:
-        context = attr.asdict(self)
+        context = self.asdict()
 
         if context["scheduled_at"]:
             context["scheduled_at"] = context["scheduled_at"].isoformat()

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -153,6 +153,7 @@ class JobDeferrer:
         self._log_before_defer_job(job=job)
         job = await self.job_manager.defer_job_async(job=job)
         self._log_after_defer_job(job=job)
+        assert job.id  # for mypy
         return job.id
 
     def defer(self, **task_kwargs: types.JSONValue) -> int:
@@ -161,4 +162,5 @@ class JobDeferrer:
         self._log_before_defer_job(job=job)
         job = self.job_manager.defer_job(job=job)
         self._log_after_defer_job(job=job)
+        assert job.id  # for mypy
         return job.id

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -47,6 +47,8 @@ class Job:
     ----------
     id :
         Internal id uniquely identifying the job.
+    status :
+        Status of the job.
     queue :
         Queue name the job will be run in.
     lock :
@@ -64,6 +66,7 @@ class Job:
     """
 
     id: Optional[int] = None
+    status: Optional[str] = None
     queue: str
     lock: Optional[str]
     queueing_lock: Optional[str]
@@ -78,6 +81,7 @@ class Job:
     def from_row(cls, row: Dict[str, Any]) -> "Job":
         return cls(
             id=row["id"],
+            status=row["status"],
             lock=row["lock"],
             queueing_lock=row["queueing_lock"],
             task_name=row["task_name"],
@@ -86,6 +90,9 @@ class Job:
             queue=row["queue_name"],
             attempts=row["attempts"],
         )
+
+    def asdict(self) -> types.JSONDict:
+        return attr.asdict(self)
 
     def log_context(self) -> types.JSONDict:
         context = attr.asdict(self)

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -144,14 +144,14 @@ class JobDeferrer:
         # Make sure this code stays synchronized with .defer()
         job = self.make_new_job(**task_kwargs)
         self._log_before_defer_job(job=job)
-        id = await self.job_manager.defer_job_async(job=job)
-        self._log_after_defer_job(job=job.evolve(id=id))
-        return id
+        job = await self.job_manager.defer_job_async(job=job)
+        self._log_after_defer_job(job=job)
+        return job.id
 
     def defer(self, **task_kwargs: types.JSONValue) -> int:
         # Make sure this code stays synchronized with .defer_async()
         job = self.make_new_job(**task_kwargs)
         self._log_before_defer_job(job=job)
-        id = self.job_manager.defer_job(job=job)
-        self._log_after_defer_job(job=job.evolve(id=id))
-        return id
+        job = self.job_manager.defer_job(job=job)
+        self._log_after_defer_job(job=job)
+        return job.id

--- a/procrastinate/jobs.py
+++ b/procrastinate/jobs.py
@@ -122,7 +122,7 @@ class JobDeferrer:
         final_kwargs = self.job.task_kwargs.copy()
         final_kwargs.update(task_kwargs)
 
-        return attr.evolve(self.job, task_kwargs=final_kwargs)
+        return self.job.evolve(task_kwargs=final_kwargs)
 
     def _log_before_defer_job(self, job: Job) -> None:
         logger.debug(

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -20,7 +20,7 @@ class JobManager:
     def __init__(self, connector: connector.BaseConnector):
         self.connector = connector
 
-    async def defer_job_async(self, job: jobs.Job) -> int:
+    async def defer_job_async(self, job: jobs.Job) -> jobs.Job:
         """
         Add a job in its queue for later processing by a worker.
 
@@ -30,8 +30,8 @@ class JobManager:
 
         Returns
         -------
-        ``int``
-            The primary key of the newly created job.
+        `jobs.Job`
+            A copy of the job instance with the id set.
         """
         # Make sure this code stays synchronized with .defer_job()
         try:
@@ -41,9 +41,9 @@ class JobManager:
         except exceptions.UniqueViolation as exc:
             self._raise_already_enqueued(exc=exc, queueing_lock=job.queueing_lock)
 
-        return result["id"]
+        return job.evolve(id=result["id"])
 
-    def defer_job(self, job: jobs.Job) -> int:
+    def defer_job(self, job: jobs.Job) -> jobs.Job:
         """
         Sync version of `defer_job_async`.
         """
@@ -54,7 +54,7 @@ class JobManager:
         except exceptions.UniqueViolation as exc:
             self._raise_already_enqueued(exc=exc, queueing_lock=job.queueing_lock)
 
-        return result["id"]
+        return job.evolve(id=result["id"])
 
     def _defer_job_query_kwargs(self, job: jobs.Job) -> Dict[str, Any]:
 

--- a/procrastinate/shell.py
+++ b/procrastinate/shell.py
@@ -100,10 +100,10 @@ class ProcrastinateShell(cmd.Cmd):
         Example: retry 2
         """
         job_id = int(arg)
-        self.job_manager.retry_job_by_id(
+        self.job_manager.retry_job_by_id(  # type: ignore
             job_id=job_id, retry_at=utils.utcnow().replace(microsecond=0)
         )
-        (job,) = self.job_manager.list_jobs(id=job_id)
+        (job,) = self.job_manager.list_jobs(id=job_id)  # type: ignore
         print_job(job)
 
     def do_cancel(self, arg: str) -> None:
@@ -116,8 +116,8 @@ class ProcrastinateShell(cmd.Cmd):
         Example: cancel 3
         """
         job_id = int(arg)
-        self.job_manager.finish_job_by_id(
+        self.job_manager.finish_job_by_id(  # type: ignore
             job_id=job_id, status=jobs.Status.FAILED, delete_job=False
         )
-        (job,) = self.job_manager.list_jobs(id=job_id)
+        (job,) = self.job_manager.list_jobs(id=job_id)  # type: ignore
         print_job(job)

--- a/procrastinate/shell.py
+++ b/procrastinate/shell.py
@@ -97,7 +97,8 @@ class ProcrastinateShell(cmd.Cmd):
 
         Example: retry 2
         """
-        print_job(self.job_manager.set_job_status(arg, status="todo"))  # type: ignore
+        output = self.job_manager.retry_job_return_info(int(arg))  # type: ignore
+        print_job(output)
 
     def do_cancel(self, arg: str) -> None:
         """
@@ -108,4 +109,5 @@ class ProcrastinateShell(cmd.Cmd):
 
         Example: cancel 3
         """
-        print_job(self.job_manager.set_job_status(arg, status="failed"))  # type: ignore
+        output = self.job_manager.cancel_job_return_info(int(arg))  # type: ignore
+        print_job(output)

--- a/procrastinate/sql/migrations/00.17.00_03_add_checks_to_finish_job.sql
+++ b/procrastinate/sql/migrations/00.17.00_03_add_checks_to_finish_job.sql
@@ -5,7 +5,7 @@ DECLARE
     _job_id bigint;
 BEGIN
     IF end_status NOT IN ('succeeded', 'failed') THEN
-        RAISE 'End status should be either "succeeded" or "failed"';
+        RAISE 'End status should be either "succeeded" or "failed" (job id: %)', job_id;
     END IF;
     IF delete_job THEN
         DELETE FROM procrastinate_jobs
@@ -23,8 +23,7 @@ BEGIN
         RETURNING id INTO _job_id;
     END IF;
     IF _job_id IS NULL THEN
-        RAISE 'Job with id % was not found or not in "doing" or "todo" status', job_id;
+        RAISE 'Job was not found or not in "doing" or "todo" status (job id: %)', job_id;
     END IF;
 END;
 $$;
-

--- a/procrastinate/sql/migrations/00.17.00_03_add_checks_to_finish_job.sql
+++ b/procrastinate/sql/migrations/00.17.00_03_add_checks_to_finish_job.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, delete_job boolean) RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    _job_id bigint;
+BEGIN
+    IF end_status NOT IN ('succeeded', 'failed') THEN
+        RAISE 'End status should be either "succeeded" or "failed"';
+    END IF;
+    IF delete_job THEN
+        DELETE FROM procrastinate_jobs
+        WHERE id = job_id AND status IN ('todo', 'doing')
+        RETURNING id INTO _job_id;
+    ELSE
+        UPDATE procrastinate_jobs
+        SET status = end_status,
+            attempts =
+                CASE
+                    WHEN status = 'doing' THEN attempts + 1
+                    ELSE attempts
+                END
+        WHERE id = job_id AND status IN ('todo', 'doing')
+        RETURNING id INTO _job_id;
+    END IF;
+    IF _job_id IS NULL THEN
+        RAISE 'Job with id % was not found or not in "doing" or "todo" status', job_id;
+    END IF;
+END;
+$$;
+

--- a/procrastinate/sql/migrations/00.17.00_04_add_checks_to_retry_job.sql
+++ b/procrastinate/sql/migrations/00.17.00_04_add_checks_to_retry_job.sql
@@ -11,8 +11,7 @@ BEGIN
     WHERE id = job_id AND status = 'doing'
     RETURNING id INTO _job_id;
     IF _job_id IS NULL THEN
-        RAISE 'Job with id % was not found or not in "doing" status', job_id;
+        RAISE 'Job was not found or not in "doing" status (job id: %)', job_id;
     END IF;
 END;
 $$;
-

--- a/procrastinate/sql/migrations/00.17.00_04_add_checks_to_retry_job.sql
+++ b/procrastinate/sql/migrations/00.17.00_04_add_checks_to_retry_job.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION procrastinate_retry_job(job_id integer, retry_at timestamp with time zone) RETURNS void
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    _job_id bigint;
+BEGIN
+    UPDATE procrastinate_jobs
+    SET status = 'todo',
+        attempts = attempts + 1,
+        scheduled_at = retry_at
+    WHERE id = job_id AND status = 'doing'
+    RETURNING id INTO _job_id;
+    IF _job_id IS NULL THEN
+        RAISE 'Job with id % was not found or not in "doing" status', job_id;
+    END IF;
+END;
+$$;
+

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -14,12 +14,12 @@ SELECT procrastinate_defer_periodic_job(%(queue)s, %(lock)s, %(queueing_lock)s, 
 
 -- fetch_job --
 -- Get the first awaiting job
-SELECT id, task_name, lock, queueing_lock, args, scheduled_at, queue_name, attempts
+SELECT id, status, task_name, lock, queueing_lock, args, scheduled_at, queue_name, attempts
     FROM procrastinate_fetch_job(%(queues)s);
 
 -- select_stalled_jobs --
 -- Get running jobs that started more than a given time ago
-SELECT job.id, task_name, lock, queueing_lock, args, scheduled_at, queue_name, attempts, max(event.at) started_at
+SELECT job.id, status, task_name, lock, queueing_lock, args, scheduled_at, queue_name, attempts, max(event.at) started_at
     FROM procrastinate_jobs job
     JOIN procrastinate_events event
       ON event.job_id = job.id

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -149,8 +149,3 @@ SELECT task_name AS name,
   FROM jobs AS j
  GROUP BY name
  ORDER BY name;
-
--- set_job_status --
-UPDATE procrastinate_jobs
-   SET status = %(status)s
- WHERE id = %(id)s

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -233,12 +233,18 @@ $$;
 CREATE FUNCTION procrastinate_retry_job(job_id integer, retry_at timestamp with time zone) RETURNS void
     LANGUAGE plpgsql
 AS $$
+DECLARE
+    _job_id bigint;
 BEGIN
     UPDATE procrastinate_jobs
     SET status = 'todo',
         attempts = attempts + 1,
         scheduled_at = retry_at
-    WHERE id = job_id;
+    WHERE id = job_id AND status = 'doing'
+    RETURNING id INTO _job_id;
+    IF _job_id IS NULL THEN
+        RAISE 'Job with id % was not found or not in "doing" status', job_id;
+    END IF;
 END;
 $$;
 

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -203,14 +203,29 @@ $$;
 CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, delete_job boolean) RETURNS void
     LANGUAGE plpgsql
 AS $$
+DECLARE
+    _job_id bigint;
 BEGIN
+    IF end_status NOT IN ('succeeded', 'failed') THEN
+        RAISE 'End status should be either "succeeded" or "failed"';
+    END IF;
     IF delete_job THEN
-        DELETE FROM procrastinate_jobs WHERE id = job_id;
+        DELETE FROM procrastinate_jobs
+        WHERE id = job_id AND status IN ('todo', 'doing')
+        RETURNING id INTO _job_id;
     ELSE
         UPDATE procrastinate_jobs
         SET status = end_status,
-            attempts = attempts + 1
-        WHERE id = job_id;
+            attempts =
+                CASE
+                    WHEN status = 'doing' THEN attempts + 1
+                    ELSE attempts
+                END
+        WHERE id = job_id AND status IN ('todo', 'doing')
+        RETURNING id INTO _job_id;
+    END IF;
+    IF _job_id IS NULL THEN
+        RAISE 'Job with id % was not found or not in "doing" or "todo" status', job_id;
     END IF;
 END;
 $$;

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -207,7 +207,7 @@ DECLARE
     _job_id bigint;
 BEGIN
     IF end_status NOT IN ('succeeded', 'failed') THEN
-        RAISE 'End status should be either "succeeded" or "failed"';
+        RAISE 'End status should be either "succeeded" or "failed" (job id: %)', job_id;
     END IF;
     IF delete_job THEN
         DELETE FROM procrastinate_jobs
@@ -225,7 +225,7 @@ BEGIN
         RETURNING id INTO _job_id;
     END IF;
     IF _job_id IS NULL THEN
-        RAISE 'Job with id % was not found or not in "doing" or "todo" status', job_id;
+        RAISE 'Job was not found or not in "doing" or "todo" status (job id: %)', job_id;
     END IF;
 END;
 $$;
@@ -243,7 +243,7 @@ BEGIN
     WHERE id = job_id AND status = 'doing'
     RETURNING id INTO _job_id;
     IF _job_id IS NULL THEN
-        RAISE 'Job with id % was not found or not in "doing" status', job_id;
+        RAISE 'Job was not found or not in "doing" status (job id: %)', job_id;
     END IF;
 END;
 $$;

--- a/tests/acceptance/test_shell.py
+++ b/tests/acceptance/test_shell.py
@@ -25,7 +25,6 @@ def test_shell(shell, defer):
     print("cancel 2", file=shell.stdin)
     print("cancel 3", file=shell.stdin)
     print("cancel 4", file=shell.stdin)
-    print("retry 3", file=shell.stdin)
 
     print("list_jobs", file=shell.stdin)
     print("list_jobs queue=other details", file=shell.stdin)
@@ -38,26 +37,25 @@ def test_shell(shell, defer):
     assert shell.stdout.readlines() == [
         "Welcome to the procrastinate shell.   Type help or ? to list commands.\n",
         "\n",
-        # cancel / retry
+        # cancel
         "procrastinate> #2 tests.acceptance.app.sum_task on default - [failed]\n",
         "procrastinate> #3 tests.acceptance.app.sum_task on other - [failed]\n",
         "procrastinate> #4 tests.acceptance.app.increment_task on default - [failed]\n",
-        "procrastinate> #3 tests.acceptance.app.sum_task on other - [todo]\n",
         # list_jobs
         "procrastinate> #1 tests.acceptance.app.sum_task on default - [todo]\n",
         "#2 tests.acceptance.app.sum_task on default - [failed]\n",
-        "#3 tests.acceptance.app.sum_task on other - [todo]\n",
+        "#3 tests.acceptance.app.sum_task on other - [failed]\n",
         "#4 tests.acceptance.app.increment_task on default - [failed]\n",
         # list_jobs queue=other details
-        "procrastinate> #3 tests.acceptance.app.sum_task on other - [todo] "
+        "procrastinate> #3 tests.acceptance.app.sum_task on other - [failed] "
         "(attempts=0, scheduled_at=None, args={'a': 1, 'b': 2}, lock=lock)\n",
         # list_queues
         "procrastinate> default: 3 jobs (todo: 1, succeeded: 0, failed: 2)\n",
-        "other: 1 jobs (todo: 1, succeeded: 0, failed: 0)\n",
+        "other: 1 jobs (todo: 0, succeeded: 0, failed: 1)\n",
         # list_tasks
         "procrastinate> tests.acceptance.app.increment_task: 1 jobs "
         "(todo: 0, succeeded: 0, failed: 1)\n",
-        "tests.acceptance.app.sum_task: 3 jobs " "(todo: 2, succeeded: 0, failed: 1)\n",
+        "tests.acceptance.app.sum_task: 3 jobs " "(todo: 1, succeeded: 0, failed: 2)\n",
         #
         "procrastinate> ",
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,15 @@ def job_factory(serial, random_str):
     return factory
 
 
+@pytest.fixture
+def deferred_job_factory(job_factory, job_manager):
+    async def factory(*, job_manager=job_manager, **kwargs):
+        job = job_factory(id=None, **kwargs)
+        return await job_manager.defer_job_async(job)
+
+    return factory
+
+
 def aware_datetime(
     year, month, day, hour=0, minute=0, second=0, microsecond=0, tz_offset=None
 ):

--- a/tests/integration/test_aiopg_connector.py
+++ b/tests/integration/test_aiopg_connector.py
@@ -114,6 +114,18 @@ async def test_execute_query(aiopg_connector):
     assert result == [{"obj_description": "foo"}]
 
 
+async def test_execute_query_no_interpolate(aiopg_connector):
+    result = await aiopg_connector.execute_query_one_async("SELECT '%(foo)s' as foo;")
+    assert result == {"foo": "%(foo)s"}
+
+
+async def test_execute_query_interpolate(aiopg_connector):
+    result = await aiopg_connector.execute_query_one_async(
+        "SELECT %(foo)s as foo;", foo="bar"
+    )
+    assert result == {"foo": "bar"}
+
+
 @pytest.mark.filterwarnings("error::ResourceWarning")
 async def test_execute_query_simultaneous(aiopg_connector):
     # two coroutines doing execute_query_async simulteneously

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -322,11 +322,9 @@ async def test_defer_job_violate_queueing_lock(pg_job_manager, job_factory):
                 task_kwargs={"c": "d"},
             )
         )
-        assert isinstance(excinfo.value.__cause__, psycopg2.errors.UniqueViolation)
-        assert (
-            excinfo.value.__cause__.diag.constraint_name
-            == "procrastinate_jobs_queueing_lock_idx"
-        )
+    cause = excinfo.value.__cause__
+    assert isinstance(cause, exceptions.UniqueViolation)
+    assert cause.constraint_name == "procrastinate_jobs_queueing_lock_idx"
 
 
 async def test_check_connection(pg_job_manager):

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -253,7 +253,7 @@ async def test_finish_job_wrong_initial_status(
         await pg_job_manager.finish_job(
             job=job, status=jobs.Status.FAILED, delete_job=delete_job
         )
-    assert f'Job was not found or not in "doing" or "todo" status' in str(
+    assert 'Job was not found or not in "doing" or "todo" status' in str(
         excinfo.value.__cause__
     )
 

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -18,6 +18,7 @@ def test_job_get_context(job_factory, scheduled_at, context_scheduled_at):
 
     job = job_factory(
         id=12,
+        status="doing",
         queue="marsupilami",
         lock="sher",
         queueing_lock="houba",
@@ -29,6 +30,7 @@ def test_job_get_context(job_factory, scheduled_at, context_scheduled_at):
 
     assert job.log_context() == {
         "id": 12,
+        "status": "doing",
         "queue": "marsupilami",
         "lock": "sher",
         "queueing_lock": "houba",

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -10,13 +10,13 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_manager_defer_job(job_manager, job_factory, connector):
-    job_row = await job_manager.defer_job_async(
+    job = await job_manager.defer_job_async(
         job=job_factory(
             task_kwargs={"a": "b"}, queue="marsupilami", task_name="bla", lock="sher"
         )
     )
 
-    assert job_row == 1
+    assert job.id == 1
 
     assert connector.jobs == {
         1: {

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -79,9 +79,10 @@ async def test_fetch_job_no_suitable_job(job_manager):
 
 
 async def test_fetch_job(job_manager, job_factory):
-    job = job_factory(id=1)
+    job = job_factory(id=None)
     await job_manager.defer_job_async(job=job)
-    assert await job_manager.fetch_job(queues=None) == job
+    expected_job = job.evolve(id=1, status="doing")
+    assert await job_manager.fetch_job(queues=None) == expected_job
 
 
 async def test_get_stalled_jobs_not_stalled(job_manager, job_factory):
@@ -91,11 +92,12 @@ async def test_get_stalled_jobs_not_stalled(job_manager, job_factory):
 
 
 async def test_get_stalled_jobs_stalled(job_manager, job_factory, connector):
-    job = job_factory(id=1)
+    job = job_factory()
     await job_manager.defer_job_async(job=job)
     await job_manager.fetch_job(queues=None)
     connector.events[1][-1]["at"] = conftest.aware_datetime(2000, 1, 1)
-    assert await job_manager.get_stalled_jobs(nb_seconds=1000) == [job]
+    expected_job = job.evolve(id=1, status="doing")
+    assert await job_manager.get_stalled_jobs(nb_seconds=1000) == [expected_job]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -3,6 +3,8 @@ import pytest
 from procrastinate import manager
 from procrastinate import shell as shell_module
 
+from .. import conftest
+
 
 @pytest.fixture
 def shell(connector):
@@ -18,8 +20,22 @@ def test_EOF(shell):
 
 
 def test_list_jobs(shell, connector, capsys):
-    connector.defer_job_one("task1", "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", "lock2", "queueing_lock2", {}, 0, "queue2")
+    connector.defer_job_one(
+        "task1",
+        "lock1",
+        "queueing_lock1",
+        {},
+        conftest.aware_datetime(2000, 1, 1),
+        "queue1",
+    )
+    connector.defer_job_one(
+        "task2",
+        "lock2",
+        "queueing_lock2",
+        {},
+        conftest.aware_datetime(2000, 1, 1),
+        "queue2",
+    )
 
     shell.do_list_jobs("")
     captured = capsys.readouterr()
@@ -43,8 +59,22 @@ def test_list_jobs(shell, connector, capsys):
 
 
 def test_list_jobs_filters(shell, connector, capsys):
-    connector.defer_job_one("task1", "lock1", "queueing_lock1", {}, 0, "queue1")
-    connector.defer_job_one("task2", "lock2", "queueing_lock2", {}, 0, "queue2")
+    connector.defer_job_one(
+        "task1",
+        "lock1",
+        "queueing_lock1",
+        {},
+        conftest.aware_datetime(2000, 1, 1),
+        "queue1",
+    )
+    connector.defer_job_one(
+        "task2",
+        "lock2",
+        "queueing_lock2",
+        {},
+        conftest.aware_datetime(2000, 1, 1),
+        "queue2",
+    )
 
     shell.do_list_jobs("id=2 queue=queue2 task=task2 lock=lock2 status=todo")
     captured = capsys.readouterr()
@@ -68,19 +98,29 @@ def test_list_jobs_filters(shell, connector, capsys):
 
 def test_list_jobs_details(shell, connector, capsys):
     connector.defer_job_one(
-        "task1", "lock1", "queueing_lock1", {"x": 11}, 1000, "queue1"
+        "task1",
+        "lock1",
+        "queueing_lock1",
+        {"x": 11},
+        conftest.aware_datetime(1000, 1, 1),
+        "queue1",
     )
     connector.defer_job_one(
-        "task2", "lock2", "queueing_lock2", {"y": 22}, 2000, "queue2"
+        "task2",
+        "lock2",
+        "queueing_lock2",
+        {"y": 22},
+        conftest.aware_datetime(2000, 1, 1),
+        "queue2",
     )
 
     shell.do_list_jobs("details")
     captured = capsys.readouterr()
     assert captured.out.splitlines() == [
-        "#1 task1 on queue1 - [todo] (attempts=0, scheduled_at=1000, "
-        "args={'x': 11}, lock=lock1)",
-        "#2 task2 on queue2 - [todo] (attempts=0, scheduled_at=2000, "
-        "args={'y': 22}, lock=lock2)",
+        "#1 task1 on queue1 - [todo] (attempts=0, scheduled_at=1000-01-01 "
+        "00:00:00+00:00, args={'x': 11}, lock=lock1)",
+        "#2 task2 on queue2 - [todo] (attempts=0, scheduled_at=2000-01-01 "
+        "00:00:00+00:00, args={'y': 22}, lock=lock2)",
     ]
 
 
@@ -183,7 +223,14 @@ def test_list_tasks_empty(shell, connector, capsys):
 
 
 def test_retry(shell, connector, capsys):
-    connector.defer_job_one("task", "lock", "queueing_lock", {}, 0, "queue")
+    connector.defer_job_one(
+        "task",
+        "lock",
+        "queueing_lock",
+        {},
+        conftest.aware_datetime(2000, 1, 1),
+        "queue",
+    )
     connector.set_job_status_run(1, "failed")
 
     shell.do_list_jobs("id=1")
@@ -196,7 +243,14 @@ def test_retry(shell, connector, capsys):
 
 
 def test_cancel(shell, connector, capsys):
-    connector.defer_job_one("task", "lock", "queueing_lock", {}, 0, "queue")
+    connector.defer_job_one(
+        "task",
+        "lock",
+        "queueing_lock",
+        {},
+        conftest.aware_datetime(2000, 1, 1),
+        "queue",
+    )
 
     shell.do_list_jobs("id=1")
     captured = capsys.readouterr()


### PR DESCRIPTION
This PR provides a number of things:

* Change the `procrastinate_finish_job` SQL function to raise an error when the job status is not "todo" or "doing" (#331).
* Change the `procrastinate_retry_job` SQL function to raise an error when the job status is not "doing"
* Change the shell's `retry job` and `cancel job` actions to rely on the above functions (#330).

Closes #331 #330

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
