### PR TITLE
Add the ability to personalize log format by environment variable

### DIFF
--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -21,7 +21,7 @@ CONTEXT_SETTINGS = {
     "auto_envvar_prefix": ENV_PREFIX,
 }
 
-LOG_FORMAT = os.environ.setdefault(f"{ENV_PREFIX}_LOG_FORMAT", "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s")
+LOG_FORMAT = os.environ.setdefault(f"{ENV_PREFIX}_LOG_FORMAT", logging.BASIC_FORMAT)
 
 
 def get_log_level(verbosity: int) -> int:

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -21,6 +21,8 @@ CONTEXT_SETTINGS = {
     "auto_envvar_prefix": ENV_PREFIX,
 }
 
+LOG_FORMAT = os.environ.setdefault(f"{ENV_PREFIX}_LOG_FORMAT", "%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s")
+
 
 def get_log_level(verbosity: int) -> int:
     """
@@ -38,7 +40,7 @@ def click_set_verbosity(ctx: click.Context, param: click.Parameter, value: int) 
 def set_verbosity(verbosity: int) -> None:
     level = get_log_level(verbosity=verbosity)
     logging.basicConfig(level=level)
-    level_name = logging.getLevelName(level)
+    level_name = logging.getLevelName(level, format=LOG_FORMAT)
     logger.debug(
         f"Log level set to {level_name}",
         extra={"action": "set_log_level", "value": level_name},

--- a/procrastinate/cli.py
+++ b/procrastinate/cli.py
@@ -39,8 +39,8 @@ def click_set_verbosity(ctx: click.Context, param: click.Parameter, value: int) 
 
 def set_verbosity(verbosity: int) -> None:
     level = get_log_level(verbosity=verbosity)
-    logging.basicConfig(level=level)
-    level_name = logging.getLevelName(level, format=LOG_FORMAT)
+    logging.basicConfig(level=level, format=LOG_FORMAT)
+    level_name = logging.getLevelName(level)
     logger.debug(
         f"Log level set to {level_name}",
         extra={"action": "set_log_level", "value": level_name},

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,7 +22,7 @@ def test_set_verbosity(mocker, caplog):
 
     cli.set_verbosity(1)
 
-    config.assert_called_once_with(level=logging.DEBUG)
+    config.assert_called_once_with(level=logging.DEBUG, format=logging.BASIC_FORMAT)
     records = [record for record in caplog.records if record.action == "set_log_level"]
     assert len(records) == 1
     assert records[0].value == "DEBUG"


### PR DESCRIPTION
This PR provides the ability to set log format with an environment variable `PROCRASTINATE_LOG_FORMAT` or use the default format: `%(asctime)s %(levelname)s %(name)s:%(lineno)s %(message)s`

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)
- [X] Had a good time contributing?
