### PR TITLE
Add a "Retry stalled jobs" howto

### DIFF
--- a/docs/howto/retry_stalled_jobs.rst
+++ b/docs/howto/retry_stalled_jobs.rst
@@ -1,0 +1,46 @@
+Retry stalled jobs
+==================
+
+When a worker gets a ``SIGINT`` or ``SIGTERM`` signal requesting it to terminate it
+waits for running jobs to finish before actually exiting. But, if the worker gets
+a second ``SIGINT`` or ``SIGTERM`` signal, or if it's killed with ``SIGKILL``, it will
+terminate immediately, possibly leaving jobs with the ``doing`` status in the queue.
+And, if no specific action is taken, these *stalled* jobs will remain in the queue
+forever, and their execution will never resume.
+
+To address that problem, Procrastinate offers functions that can be used in a periodic
+task for retrying stalled jobs. Add the following in your code to enable automatic retry
+of tasks after some time:
+
+.. code-block:: python
+
+
+    # time in seconds for running jobs to be deemed as stalled
+    RUNNING_JOBS_MAX_TIME = 30
+
+    @app.periodic(cron="*/10 * * * *")
+    @app.task(queueing_lock="retry_stalled_jobs", pass_context=True)
+    async def retry_stalled_jobs(context, timestamp):
+        stalled_jobs = await app.job_manager.get_stalled_jobs(
+            nb_seconds=RUNNING_JOBS_MAX_TIME
+        )
+        for job in stalled_jobs:
+            await app.job_manager.retry_job(job)
+
+This defines a periodic task, configured to be deferred at every 10th minute. The task
+retrieves all the jobs that have been in the ``doing`` status for more than
+30 seconds, and restarts them (marking them with the ``todo`` status in the database).
+
+With this, if you have multiple workers, and, for some reason, one of them gets killed
+while running jobs, then one of the remaining workers will run the
+``retry_stalled_jobs`` task, marking the stalled jobs for retry.
+
+If you have specific rules for task retry (e.g. only some tasks should be retried, based
+on specific parameters, or the duration before a task is considered stalled should
+depend on the task), you're free to make the periodic task function more complex and add
+your logic to it. See `JobManager.get_stalled_jobs` for details.
+
+Also, note that if a task is considered stalled, it will be retried, but if it's
+actually running, then you may have your task running twice. Make sure to only retry
+a task when you're reasonably sure that it is not running anymore, so make sure your
+stalled duration is sufficient.

--- a/docs/howto_index.rst
+++ b/docs/howto_index.rst
@@ -28,6 +28,7 @@ How to...
     howto/migrations
     howto/monitoring
     howto/delete_finished_jobs
+    howto/retry_stalled_jobs
     howto/connections
     howto/custom_json_encoder_decoder
     howto/schema

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -132,12 +132,12 @@ class JobManager:
         task_name: Optional[str] = None,
     ) -> Iterable[jobs.Job]:
         """
-        Return all jobs that have been in ``todo`` state for more than a given time.
+        Return all jobs that have been in ``doing`` state for more than a given time.
 
         Parameters
         ----------
         nb_seconds : ``int``
-            Only jobs that have been in ``todo`` state for longer than this will be
+            Only jobs that have been in ``doing`` state for longer than this will be
             returned
         queue : ``Optional[str]``
             Filter by job queue name

--- a/procrastinate/manager.py
+++ b/procrastinate/manager.py
@@ -224,7 +224,7 @@ class JobManager:
     async def retry_job(
         self,
         job: jobs.Job,
-        retry_at: datetime.datetime,
+        retry_at: Optional[datetime.datetime] = None,
     ) -> None:
         """
         Indicates that a job should be retried later.
@@ -232,13 +232,15 @@ class JobManager:
         Parameters
         ----------
         job : `jobs.Job`
-        retry_at : ``datetime.datetime``
+        retry_at : ``Optional[datetime.datetime]``
             If set at present time or in the past, the job may be retried immediately.
             Otherwise, the job will be retried no sooner than this date & time.
-            Should be timezone-aware (even if UTC)
+            Should be timezone-aware (even if UTC). Defaults to present time.
         """
         assert job.id  # TODO remove this
-        await self.retry_job_by_id_async(job_id=job.id, retry_at=retry_at)
+        await self.retry_job_by_id_async(
+            job_id=job.id, retry_at=retry_at or utils.utcnow()
+        )
 
     async def retry_job_by_id_async(
         self,


### PR DESCRIPTION
This PR adds a "Retry stalled jobs" howto that shows how to set up a periodic tasks responsible for retrying jobs that stalled in the queue.

With the work we did in https://github.com/peopledoc/procrastinate/pull/356 we have everything in place to make it possible to implement a "retry stalled jobs" periodic task.

Closes #307.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.md might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
- [x] Had a good time contributing?
