### PR TITLE
Fix README async example, make both `sync` and `async` example more complete

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Here's an example:
         sum.defer(a=3, b=5)
 
         # Somewhere in your program (actually, often a different
-        # program than the one defering jobs for execution), run a worker
+        # program than the one deferring jobs for execution), run a worker
         app.run_worker(queues=["sums"])
 
 The worker will run the job, which will create a text file

--- a/README.rst
+++ b/README.rst
@@ -98,9 +98,7 @@ Lastly, you can use Procrastinate asynchronously too:
     # Define asynchronous tasks using coroutine functions
     @app.task(queue="sums")
     async def sum(a, b):
-        print('async task is running')
         await asyncio.sleep(a + b)
-        print('async job is done')
 
     # Open the connection to the database `async`,
     async with app.open_async():


### PR DESCRIPTION
Closes #364

### Successful PR Checklist:
- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
- [x] Had a good time contributing?

I've made the following changes/fixes:
1. Fixed the `async` README example, that was still relying on non-existent `procrastinate.Worker`
2. Extended both examples to:
  - include necessary imports
  - include DB connection boilerplate: Easier for newbies (like me) to approach and understand how they can connect to their DB
  - use context managers instead: Generally regarded as good practice - will automatically tear down `app.open` in this case

Overall, both the `sync` and `async` examples can no be copy pasted into any script/repl and should run from top to bottom.

Looking forward to your review.