### PR TITLE
Fix finish_job compatibility issue

### DIFF
--- a/procrastinate/sql/migrations/00.18.01_01_fix_finish_job_compat_issue.sql
+++ b/procrastinate/sql/migrations/00.18.01_01_fix_finish_job_compat_issue.sql
@@ -1,11 +1,6 @@
--- remove old procrastinate_finish_job functions
--- https://github.com/peopledoc/procrastinate/pull/336
-DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status, timestamp with time zone);
--- https://github.com/peopledoc/procrastinate/pull/354
-DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status);
--- https://github.com/peopledoc/procrastinate/pull/381
-DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status, timestamp with time zone, boolean);
-CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, delete_job boolean) RETURNS void
+DROP FUNCTION IF EXISTS procrastinate_finish_job(integer, procrastinate_job_status, boolean);
+
+CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone, delete_job boolean) RETURNS void
     LANGUAGE plpgsql
 AS $$
 DECLARE

--- a/procrastinate/sql/queries.sql
+++ b/procrastinate/sql/queries.sql
@@ -48,7 +48,7 @@ WHERE id IN (
 
 -- finish_job --
 -- Finish a job, changing it from "doing" to "succeeded" or "failed"
-SELECT procrastinate_finish_job(%(job_id)s, %(status)s, %(delete_job)s);
+SELECT procrastinate_finish_job(%(job_id)s, %(status)s, NULL, %(delete_job)s);
 
 -- retry_job --
 -- Retry a job, changing it from "doing" to "todo"

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -200,7 +200,9 @@ END;
 $$;
 
 -- procrastinate_finish_job
-CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, delete_job boolean) RETURNS void
+-- the next_scheduled_at argument is kept for compatibility reasons, it is to be
+-- removed after 1.0.0 is released
+CREATE FUNCTION procrastinate_finish_job(job_id integer, end_status procrastinate_job_status, next_scheduled_at timestamp with time zone, delete_job boolean) RETURNS void
     LANGUAGE plpgsql
 AS $$
 DECLARE


### PR DESCRIPTION
This fixes an SQL compatibility issue introduced by #354.

I think this should lead to a 0.18.2 bugfix release, and upgrading to 0.18.0 and 0.18.1 should be discouraged.

Closes #381

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
