### PR TITLE
Do not raise in the BaseConnector destructor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: tox -e ${{ matrix.tox-env }}
         env:
           PGDATABASE: procrastinate
-          PGHOST: localhost
+          PGHOST: 127.0.0.1
           PGUSER: postgres
           PGPASSWORD: password
       - name: Upload coverage to Codecov

--- a/procrastinate/connector.py
+++ b/procrastinate/connector.py
@@ -53,7 +53,10 @@ class BaseConnector:
         raise exceptions.SyncConnectorConfigurationError
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except NotImplementedError:
+            pass
 
 
 @utils.add_sync_api


### PR DESCRIPTION
This is to avoid `PytestUnraisableExceptionWarning` when running `BaseConnector` tests because the destructor calls `close` which raises a `NotImplementedError`.

Closes #384.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
- [x] Had a good time contributing?
