### PR TITLE
Small fix for dev-env script

### DIFF
--- a/dev-env
+++ b/dev-env
@@ -55,15 +55,14 @@ echo ""
 echo "Database is ready!"
 echo ""
 
+export PROCRASTINATE_APP=procrastinate_demo.app.app
+
 if ! pg_dump --schema-only --table=procrastinate_jobs 1>/dev/null 2>&1; then
     echo "Applying migrations"
     procrastinate schema --apply || return
 fi
 
 echo "Migrations applied!"
-
-
-export PROCRASTINATE_APP=procrastinate_demo.app.app
 
 alias htmlcov='python -m webbrowser file://$(pwd)/htmlcov/index.html'
 alias htmldoc='python -m webbrowser file://$(pwd)/docs/_build/html/index.html'


### PR DESCRIPTION
The `PROCRASTINATE_APP` definition needs to happen before applying the schema, otherwise we get a `Missing app` error. I guess this was not detected before because the script only ran on environments where the variable was already defined or the schema already applied.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [X] (not applicable?)
- [ ] Documentation
  - [X] (not applicable?)
- [X] Had a good time contributing?
