### PR TITLE
Add index to procrastinate_jobs for improved fetch_job performance

### DIFF
--- a/procrastinate/sql/migrations/00.19.00_01_add_index_on_procrastinate_jobs.sql
+++ b/procrastinate/sql/migrations/00.19.00_01_add_index_on_procrastinate_jobs.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS procrastinate_jobs_id_lock_idx ON procrastinate_jobs (id, lock) WHERE status = ANY (ARRAY['todo'::procrastinate_job_status, 'doing'::procrastinate_job_status]);

--- a/procrastinate/sql/schema.sql
+++ b/procrastinate/sql/schema.sql
@@ -59,7 +59,10 @@ CREATE UNIQUE INDEX procrastinate_jobs_queueing_lock_idx ON procrastinate_jobs (
 CREATE UNIQUE INDEX procrastinate_jobs_lock_idx ON procrastinate_jobs (lock) WHERE status = 'doing';
 
 CREATE INDEX procrastinate_jobs_queue_name_idx ON procrastinate_jobs(queue_name);
+CREATE INDEX procrastinate_jobs_id_lock_idx ON procrastinate_jobs (id, lock) WHERE status = ANY (ARRAY['todo'::procrastinate_job_status, 'doing'::procrastinate_job_status]);
+
 CREATE INDEX procrastinate_events_job_id_fkey ON procrastinate_events(job_id);
+
 CREATE INDEX procrastinate_periodic_defers_job_id_fkey ON procrastinate_periodic_defers(job_id);
 
 


### PR DESCRIPTION

This PR adds an index to the `procrastinate_jobs` table for better performance of the `procrastinate_fetch_job` function.

This index was successfully tested by the PeopleDoc DBA team.

Closes #393

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
