### PR TITLE
Add Blueprint and lazy registration pattern

### DIFF
--- a/docs/howto/blueprints.rst
+++ b/docs/howto/blueprints.rst
@@ -1,0 +1,24 @@
+Use Blueprints
+--------------
+
+You can use blueprints to break up your tasks.
+
+Firstly use blueprints to create a task collection::
+
+    from procrastinate import blueprints
+
+    bp = blueprints.BluePrint()
+
+    @bp.task()
+    def mytask(argument, other_argument):
+        ...
+
+Then register blueprint with the app after you have created it::
+
+    from procrastinate import AiopgConnector, App
+
+    app = App(connector=AiopgConnector())
+
+    app.register_blueprint(bp)
+
+Blueprint tasks take the same arguments as `App.task`.

--- a/docs/howto/blueprints.rst
+++ b/docs/howto/blueprints.rst
@@ -1,24 +1,39 @@
-Use Blueprints
---------------
+Create modular collections of tasks by using Blueprints
+-------------------------------------------------------
 
-You can use blueprints to break up your tasks.
+Procrastinate provides Blueprints as a way to factor a large number of tasks
+into smaller self contained collections.
 
-Firstly use blueprints to create a task collection::
+You may want to create a collection for simple organsational reasons within the
+same project.  Or you may want to maintain a collection of tasks in a seperate
+package which is maintained independently of you Procrastinate server and
+workers. eg::
+
+    ...
+
+    from my_external_package import tasks_blueprint
+    ...
+
+    app.register_blueprint(tasks_blueprint)
+
+
+Blueprints are easy to use, and task creation follows the pattern and API as
+`App.task`.
+
+Firstly, create a Blueprint instance and then create some tasks::
 
     from procrastinate import Blueprint
 
-    bp = Blueprint()
+    my_blueprint = Blueprint()
 
-    @bp.task()
+    @my_blueprint.task()
     def mytask(argument, other_argument):
         ...
 
-Then register blueprint with the app after you have created it::
+In your projcet register the blueprint with the `App` after you have created it::
 
     from procrastinate import AiopgConnector, App
 
     app = App(connector=AiopgConnector())
 
-    app.register_blueprint(bp)
-
-Blueprint tasks take the same arguments as `App.task`.
+    app.register_blueprint(my_blueprint)

--- a/docs/howto/blueprints.rst
+++ b/docs/howto/blueprints.rst
@@ -5,9 +5,9 @@ You can use blueprints to break up your tasks.
 
 Firstly use blueprints to create a task collection::
 
-    from procrastinate import blueprints
+    from procrastinate import Blueprint
 
-    bp = blueprints.BluePrint()
+    bp = Blueprint()
 
     @bp.task()
     def mytask(argument, other_argument):

--- a/docs/howto_index.rst
+++ b/docs/howto_index.rst
@@ -33,3 +33,4 @@ How to...
     howto/connections
     howto/custom_json_encoder_decoder
     howto/schema
+    howto/blueprints

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -79,3 +79,9 @@ Django
 ------
 
 .. autofunction:: procrastinate.contrib.django.connector_params
+
+
+Blueprints
+----------
+
+.. autoclass:: procrastinate.blueprints.Blueprint

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -85,3 +85,4 @@ Blueprints
 ----------
 
 .. autoclass:: procrastinate.blueprints.Blueprint
+    :members: task

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -60,7 +60,8 @@ Exceptions
 
 .. automodule:: procrastinate.exceptions
     :members: ProcrastinateException, LoadFromPathError,
-              ConnectorException, AlreadyEnqueued, AppNotOpen, TaskNotFound
+              ConnectorException, AlreadyEnqueued, AppNotOpen, TaskNotFound,
+              UnboundTaskError
 
 Job statuses
 ------------

--- a/procrastinate/__init__.py
+++ b/procrastinate/__init__.py
@@ -1,6 +1,7 @@
 from procrastinate import metadata as _metadata_module
 from procrastinate.aiopg_connector import AiopgConnector
 from procrastinate.app import App
+from procrastinate.blueprints import Blueprint
 from procrastinate.connector import BaseConnector
 from procrastinate.job_context import JobContext
 from procrastinate.psycopg2_connector import Psycopg2Connector
@@ -8,6 +9,7 @@ from procrastinate.retry import BaseRetryStrategy, RetryStrategy
 
 __all__ = [
     "App",
+    "Blueprint",
     "JobContext",
     "BaseConnector",
     "BaseRetryStrategy",

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -8,7 +8,7 @@ from procrastinate import retry as retry_module
 from procrastinate import schema, utils
 
 if TYPE_CHECKING:
-    from procrastinate import tasks, worker
+    from procrastinate import blueprints, tasks, worker
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +199,9 @@ class App:
             Cron-like string. Optionally add a 6th column for seconds.
         """
         return self.periodic_deferrer.periodic_decorator(cron=cron)
+
+    def register_blueprint(self, blueprint: "blueprints.Blueprint") -> None:
+        blueprint.register(self)
 
     def _register(self, task: "tasks.Task") -> None:
         self.tasks[task.name] = task

--- a/procrastinate/app.py
+++ b/procrastinate/app.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Set
 
 from procrastinate import connector as connector_module
-from procrastinate import exceptions, jobs, manager
+from procrastinate import exceptions, jobs, manager, protocols
 from procrastinate import retry as retry_module
 from procrastinate import schema, utils
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class App:
+class App(protocols.TaskCreator):
     """
     The App is the main entry point for procrastinate integration.
 

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -21,7 +21,7 @@ class Blueprint(protocols.TaskCreator):
     Notes
     -----
     Deffering a blueprint task before the it is bound to an app will raise an
-    Assertion error::
+    UnboundTaskError::
 
         bp = Blueprint()
 

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -1,0 +1,54 @@
+import functools
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+from procrastinate import jobs, retry
+
+if TYPE_CHECKING:
+    from procrastinate import app, tasks
+
+
+class BluePrint:
+    def __init__(self):
+        self.tasks = {}
+
+    def _register_task(self, task: "tasks.Task") -> None:
+        self.tasks[task.name] = task
+
+    def register(self, app: "app.App") -> None:
+        for task in self.tasks.values():
+            app._register(task)
+
+    def task(
+        self,
+        _func: Optional[Callable] = None,
+        *,
+        name: Optional[str] = None,
+        aliases: Optional[List[str]] = None,
+        retry: retry.RetryValue = False,
+        pass_context: bool = False,
+        queue: str = jobs.DEFAULT_QUEUE,
+        lock: Optional[str] = None,
+        queueing_lock: Optional[str] = None,
+    ) -> Any:
+        def _wrap(func: Callable[..., "tasks.Task"]):
+            from procrastinate import tasks
+
+            task = tasks.Task(
+                func,
+                app=self,
+                queue=queue,
+                lock=lock,
+                queueing_lock=queueing_lock,
+                name=name,
+                aliases=aliases,
+                retry=retry,
+                pass_context=pass_context,
+            )
+            self._register_task(task)
+
+            return functools.update_wrapper(task, func, updated=())
+
+        if _func is None:  # Called as @app.task(...)
+            return _wrap
+
+        return _wrap(_func)  # Called as @app.task

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -16,6 +16,7 @@ class Blueprint(protocols.TaskCreator):
 
     def register(self, app: "app.App") -> None:
         for task in self.tasks.values():
+            task.app = app
             app._register(task)
 
     def task(
@@ -35,7 +36,7 @@ class Blueprint(protocols.TaskCreator):
 
             task = tasks.Task(
                 func,
-                app=self,
+                app=None,  # Causes a mypy error
                 queue=queue,
                 lock=lock,
                 queueing_lock=queueing_lock,

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -36,7 +36,7 @@ class Blueprint(protocols.TaskCreator):
 
             task = tasks.Task(
                 func,
-                app=None,  # Causes a mypy error
+                app=None,
                 queue=queue,
                 lock=lock,
                 queueing_lock=queueing_lock,

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 class Blueprint(protocols.TaskCreator):
     """
     A Blueprint provides a way to declare tasks that can be registered on an
-    :class:`~procrastinate.App` later::
+    `App` later::
 
         bp = Blueprint()
 
@@ -20,7 +20,7 @@ class Blueprint(protocols.TaskCreator):
 
     Notes
     -----
-    Calling a blueprint task before the it is bound to an app will raise an
+    Deffering a blueprint task before the it is bound to an app will raise an
     Assertion error::
 
         bp = Blueprint()

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from procrastinate import app, tasks
 
 
-class BluePrint:
+class Blueprint:
     def __init__(self):
         self.tasks = {}
 

--- a/procrastinate/blueprints.py
+++ b/procrastinate/blueprints.py
@@ -1,13 +1,13 @@
 import functools
 from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
-from procrastinate import jobs, retry
+from procrastinate import jobs, protocols, retry
 
 if TYPE_CHECKING:
     from procrastinate import app, tasks
 
 
-class Blueprint:
+class Blueprint(protocols.TaskCreator):
     def __init__(self):
         self.tasks = {}
 

--- a/procrastinate/exceptions.py
+++ b/procrastinate/exceptions.py
@@ -89,3 +89,11 @@ class SyncConnectorConfigurationError(ProcrastinateException):
     needs an asynchronous connector (AiopgConnector). Please check your App
     configuration.
     """
+
+
+class UnboundTaskError(ProcrastinateException):
+    """
+    The `Task` was used before it was bound to an `App`.
+    If the task is defined on a Blueprint ensure it is registered on an App
+    before it is used.
+    """

--- a/procrastinate/protocols.py
+++ b/procrastinate/protocols.py
@@ -1,0 +1,19 @@
+from typing import Any, Callable, List, Optional, Protocol
+
+from procrastinate import retry
+
+
+class TaskCreator(Protocol):
+    def task(
+        self,
+        _func: Optional[Callable],
+        *,
+        name: Optional[str],
+        aliases: Optional[List[str]],
+        retry: retry.RetryValue,
+        pass_context: bool,
+        queue: str,
+        lock: Optional[str],
+        queueing_lock: Optional[str],
+    ) -> Any:
+        ...

--- a/procrastinate/protocols.py
+++ b/procrastinate/protocols.py
@@ -1,4 +1,6 @@
-from typing import Any, Callable, List, Optional, Protocol
+from typing import Any, Callable, List, Optional
+
+from typing_extensions import Protocol
 
 from procrastinate import retry
 

--- a/procrastinate/protocols.py
+++ b/procrastinate/protocols.py
@@ -2,20 +2,20 @@ from typing import Any, Callable, List, Optional
 
 from typing_extensions import Protocol
 
-from procrastinate import retry
+from procrastinate import jobs, retry
 
 
 class TaskCreator(Protocol):
     def task(
         self,
-        _func: Optional[Callable],
+        _func: Optional[Callable] = None,
         *,
-        name: Optional[str],
-        aliases: Optional[List[str]],
-        retry: retry.RetryValue,
-        pass_context: bool,
-        queue: str,
-        lock: Optional[str],
-        queueing_lock: Optional[str],
+        name: Optional[str] = None,
+        aliases: Optional[List[str]] = None,
+        retry: retry.RetryValue = False,
+        pass_context: bool = False,
+        queue: str = jobs.DEFAULT_QUEUE,
+        lock: Optional[str] = None,
+        queueing_lock: Optional[str] = None,
     ) -> Any:
         ...

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -168,7 +168,9 @@ class Task:
             If you try to define both schedule_at and schedule_in
         """
         if self.app is None:
-            raise AssertionError("Tried to configure task whilst self.app was None")
+            raise exceptions.UnboundTaskError(
+                "Tried to configure task whilst self.app was None"
+            )
 
         return configure_task(
             name=self.name,

--- a/procrastinate/tasks.py
+++ b/procrastinate/tasks.py
@@ -72,7 +72,7 @@ class Task:
         self,
         func: Callable,
         *,
-        app: app.App,
+        app: Optional[app.App],
         # task naming
         name: Optional[str] = None,
         aliases: Optional[List[str]] = None,
@@ -167,6 +167,9 @@ class Task:
         ValueError
             If you try to define both schedule_at and schedule_in
         """
+        if self.app is None:
+            raise AssertionError("Tried to configure task whilst self.app was None")
+
         return configure_task(
             name=self.name,
             job_manager=self.app.job_manager,

--- a/tests/acceptance/app.py
+++ b/tests/acceptance/app.py
@@ -38,9 +38,16 @@ sync_app = procrastinate.App(
 sync_app.open()
 
 
-@app.task(queue="default")
+# Check that tasks can be added from blueprints
+bp = procrastinate.Blueprint()
+
+
+@bp.task(queue="default")
 def sum_task(a, b):
     print(a + b)
+
+
+app.register_blueprint(bp)
 
 
 @app.task(queue="default")

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -1,6 +1,6 @@
 import pytest
 
-from procrastinate import blueprints, retry
+from procrastinate import blueprints, exceptions, retry
 
 
 def test_app_task_explicit(app, mocker):
@@ -55,5 +55,5 @@ def test_app_task_configure_before_binding_not_allowed(app):
     def wrapped():
         return "foo"
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(exceptions.UnboundTaskError):
         wrapped.configure()

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -1,0 +1,28 @@
+from procrastinate import blueprints, retry
+
+
+def test_app_task_explicit(app, mocker):
+    bp = blueprints.BluePrint()
+
+    @bp.task(
+        name="foobar",
+        queue="bar",
+        lock="sher",
+        queueing_lock="baz",
+        retry=True,
+        pass_context=True,
+    )
+    def wrapped():
+        return "foo"
+
+    app.register_blueprint(bp)
+
+    assert wrapped() == "foo"
+    assert app.tasks["foobar"].name == "foobar"
+    assert app.tasks["foobar"].queue == "bar"
+    assert app.tasks["foobar"].lock == "sher"
+    assert app.tasks["foobar"].queueing_lock == "baz"
+    assert isinstance(app.tasks["foobar"].retry_strategy, retry.RetryStrategy)
+    assert app.tasks["foobar"].pass_context is True
+    assert app.tasks["foobar"] is wrapped
+    assert app.tasks["foobar"].func is wrapped.__wrapped__

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -2,7 +2,7 @@ from procrastinate import blueprints, retry
 
 
 def test_app_task_explicit(app, mocker):
-    bp = blueprints.BluePrint()
+    bp = blueprints.Blueprint()
 
     @bp.task(
         name="foobar",

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -1,3 +1,5 @@
+import pytest
+
 from procrastinate import blueprints, retry
 
 
@@ -44,3 +46,14 @@ def test_app_task_implicit(app):
     assert "default" == registered_task.queue
     assert registered_task is wrapped
     assert registered_task.func is wrapped.__wrapped__
+
+
+def test_app_task_configure_before_binding_not_allowed(app):
+    bp = blueprints.Blueprint()
+
+    @bp.task()
+    def wrapped():
+        return "foo"
+
+    with pytest.raises(AssertionError):
+        wrapped.configure()

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -26,3 +26,21 @@ def test_app_task_explicit(app, mocker):
     assert app.tasks["foobar"].pass_context is True
     assert app.tasks["foobar"] is wrapped
     assert app.tasks["foobar"].func is wrapped.__wrapped__
+
+
+def test_app_task_implicit(app):
+    bp = blueprints.Blueprint()
+
+    @bp.task
+    def wrapped():
+        return "foo"
+
+    app.register_blueprint(bp)
+
+    registered_task = app.tasks["tests.unit.test_blueprints.wrapped"]
+
+    assert "foo" == wrapped()
+    assert "tests.unit.test_blueprints.wrapped" == registered_task.name
+    assert "default" == registered_task.queue
+    assert registered_task is wrapped
+    assert registered_task.func is wrapped.__wrapped__

--- a/tests/unit/test_task_creation_signatures.py
+++ b/tests/unit/test_task_creation_signatures.py
@@ -1,6 +1,7 @@
 import inspect
 
 from procrastinate import App, Blueprint
+from procrastinate.protocols import TaskCreator
 
 
 # def test_task_signatures(app, mocker):
@@ -12,4 +13,8 @@ def test_task_signatures():
     This is further enforced with protocols.TaskCreator and mypy checks.
     """
 
-    assert inspect.signature(Blueprint.task) == inspect.signature(App.task)
+    # Check that both App.task and Blueprint.task implement Taskcreator.task
+    assert inspect.signature(App.task) == inspect.signature(TaskCreator.task)
+    assert inspect.signature(Blueprint.task) == inspect.signature(TaskCreator.task)
+    # Sanity check
+    assert inspect.signature(App.task) == inspect.signature(Blueprint.task)

--- a/tests/unit/test_task_creation_signatures.py
+++ b/tests/unit/test_task_creation_signatures.py
@@ -1,0 +1,15 @@
+import inspect
+
+from procrastinate import blueprints
+
+
+def test_task_signatures(app, mocker):
+    """Tasks can be created in two ways, both of which need to maintain an
+    identical API.  This test simple test that App.task and Blueprint.task have
+    the same function signature.
+
+    This is further enforced with protocols.TaskCreator and mypy checks.
+    """
+
+    bp = blueprints.Blueprint()
+    assert inspect.signature(bp.task) == inspect.signature(app.task)

--- a/tests/unit/test_task_creation_signatures.py
+++ b/tests/unit/test_task_creation_signatures.py
@@ -1,9 +1,10 @@
 import inspect
 
-from procrastinate import blueprints
+from procrastinate import App, Blueprint
 
 
-def test_task_signatures(app, mocker):
+# def test_task_signatures(app, mocker):
+def test_task_signatures():
     """Tasks can be created in two ways, both of which need to maintain an
     identical API.  This test simple test that App.task and Blueprint.task have
     the same function signature.
@@ -11,5 +12,4 @@ def test_task_signatures(app, mocker):
     This is further enforced with protocols.TaskCreator and mypy checks.
     """
 
-    bp = blueprints.Blueprint()
-    assert inspect.signature(bp.task) == inspect.signature(app.task)
+    assert inspect.signature(Blueprint.task) == inspect.signature(App.task)


### PR DESCRIPTION
Enables collections of tasks to be defined independently of the app
itself and registered at a later time.

Closes #421 

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)
