### PR TITLE
Psycopg2: % in queries need to be escaped

### DIFF
--- a/tests/integration/test_psycopg2_connector.py
+++ b/tests/integration/test_psycopg2_connector.py
@@ -91,6 +91,24 @@ def test_execute_query(psycopg2_connector):
     assert result == [{"obj_description": "foo"}]
 
 
+def test_execute_query_percent(psycopg2_connector):
+    psycopg2_connector.execute_query("SELECT '%'")
+    result = psycopg2_connector.execute_query_one("SELECT '%'")
+    assert result == {"?column?": "%"}
+
+    result = psycopg2_connector.execute_query_all("SELECT '%'")
+    assert result == [{"?column?": "%"}]
+
+
+def test_execute_query_arg(psycopg2_connector):
+    psycopg2_connector.execute_query("SELECT %(arg)s", arg=1)
+    result = psycopg2_connector.execute_query_one("SELECT %(arg)s", arg=1)
+    assert result == {"?column?": 1}
+
+    result = psycopg2_connector.execute_query_all("SELECT %(arg)s", arg=1)
+    assert result == [{"?column?": 1}]
+
+
 def test_close(psycopg2_connector):
     pool = psycopg2_connector._pool
     psycopg2_connector.close()


### PR DESCRIPTION
Closes #409

2 kinds of `%` may appear in queries:
- Python placeholders (`%s` or `%(foo)s`): must **NOT** be escaped
- Literal `%` sent to the DB as part of the queries: must be escaped
This PR replaces `%` that are not followed by `(` or `s` with `%%`.
It also adds tests for psycopg2 showing that literal `%` are valid, and `%(foo)s` is not escaped.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
