### PR TITLE
path_hook should raise ImportError when a module isn't found

### DIFF
--- a/procrastinate/contrib/django/README.md
+++ b/procrastinate/contrib/django/README.md
@@ -62,12 +62,12 @@ sure we can recognize easily. That's what we do with `VIRTUAL_PATH`.
 
 Step B: Ok, we've returned a module for `p.c.d.migrations`, now Django will be running
 `pkgutil.iter_modules` on our module's `__path__` (`VIRTUAL_PATH`). This results in
-Python calling all the callables in sys.path_hooks with our path until one doesn't raise
-ImportError. The default path hooks will all fail, we need our own hook. That's why in
-the load() function mentionned below, we also added our importer's path_hook method to
-sys.path_hook. We get called and check that the path is the VIRTUAL_PATH that we set
+Python calling all the callables in `sys.path_hooks` with our path until one doesn't raise
+`ImportError`. The default path hooks will all fail, we need our own hook. That's why in
+the `load()` function mentionned below, we also added our importer's `path_hook` method to
+`sys.path_hook`. We get called and check that the path is the `VIRTUAL_PATH` that we set
 earlier. The path hook needs to return a Finder object suitable for listing its
-submodules, so that would be self.
+submodules, so that would be `self`
 
 Now Python will call a non-standard method on our finder: `iter_modules`
 (https://docs.python.org/3/library/pkgutil.html?highlight=iter_modules#`pkgutil.iter_modules`)

--- a/procrastinate/contrib/django/migrations_magic.py
+++ b/procrastinate/contrib/django/migrations_magic.py
@@ -55,7 +55,7 @@ class ProcrastinateMigrationsImporter(abc.MetaPathFinder, abc.Loader):
     def path_hook(self, path: str) -> Optional["ProcrastinateMigrationsImporter"]:
         if path == VIRTUAL_PATH:
             return self
-        return None
+        raise ImportError
 
 
 def load():

--- a/tests/unit/contrib/django/test_migrations_magic.py
+++ b/tests/unit/contrib/django/test_migrations_magic.py
@@ -137,7 +137,8 @@ def test_importer_path_hook(importer):
 
 
 def test_importer_path_hook_other_package(importer):
-    assert importer.path_hook("/some/other/path") is None
+    with pytest.raises(ImportError):
+        importer.path_hook("/some/other/path")
 
 
 @pytest.fixture


### PR DESCRIPTION
Who would have guessed that [giving a talk](https://2021.pycon.org.au/program/t7z9ve/) at an international conference that is specifically about this very module would lead me to change some bits? :surprised-pikachu:

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
