### PR TITLE
Remove redundant word in worker logging

### DIFF
--- a/procrastinate/worker.py
+++ b/procrastinate/worker.py
@@ -148,7 +148,7 @@ class Worker:
     async def wait_for_job(self, timeout: float):
         assert self.notify_event
         self.logger.debug(
-            f"Waiting for new jobs on queues " f"{self.base_context.queues_display}",
+            f"Waiting for new jobs on " f"{self.base_context.queues_display}",
             extra=self.base_context.log_extra(
                 action="waiting_for_jobs", queues=self.queues
             ),


### PR DESCRIPTION
```
[cloud-app-worker-k8s] DEBUG:procrastinate.worker.worker:Waiting for new jobs on queues queues k8s
[cloud-app-worker-email] DEBUG:procrastinate.worker.worker:Waiting for new jobs on queues queues email
```

One too many "queues"!

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
