### PR TITLE
Fix docstring and Psycopg2Connector __init__ signature

### DIFF
--- a/procrastinate/psycopg2_connector.py
+++ b/procrastinate/psycopg2_connector.py
@@ -76,7 +76,6 @@ class Psycopg2Connector(connector.BaseConnector):
         *,
         json_dumps: Optional[Callable] = None,
         json_loads: Optional[Callable] = None,
-        pool: Optional[psycopg2.pool.ThreadedConnectionPool] = None,
         **kwargs: Any,
     ):
         """

--- a/procrastinate/psycopg2_connector.py
+++ b/procrastinate/psycopg2_connector.py
@@ -16,8 +16,7 @@ logger = logging.getLogger(__name__)
 
 def wrap_exceptions(func: Callable) -> Callable:
     """
-    Wrap psycopg2 errors as connector exceptions
-    This decorator is expected to be used on coroutine functions only
+    Wrap psycopg2 errors as connector exceptions.
     """
 
     @functools.wraps(func)


### PR DESCRIPTION
This PR includes two minor changes to `psycopg2_connector.py`:

* removal of an erroneous docstring for the `wrap_exceptions` decorator function,
* removal of the `pool` argument to the `Psycopg2Connector.__init__` function.

<!-- Please do not remove this, even if you think you don't need it -->
### Successful PR Checklist:
<!-- In case of doubt, we're here to help. CONTRIBUTING.rst might help too -->
- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)
